### PR TITLE
Feat/zhanna issue5 adding claude support develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.py[cod]
 .DS_Store
+
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,34 +1,43 @@
-# GitHub Issue -> OpenCode Runner
+# GitHub Issue -> AI Agent Runner
 
-Script fetches GitHub issues via `gh`, runs OpenCode agent on each issue body, and then automates git workflow for a fix branch.
+Script fetches GitHub issues via `gh`, runs an AI agent on each issue body, and then automates git workflow for a fix branch.
 
 ## Requirements
 
 - `gh` (GitHub CLI) authenticated (`gh auth status`)
-- `opencode` installed and configured
 - Python 3.10+
+- `claude` (Claude Code CLI) — default runner
+- `opencode` — only if using `--runner opencode`
 
 ## Usage
 
+**With Claude (default):**
 ```bash
-./scripts/run_github_issues_to_opencode.py --repo owner/repo --limit 1 --agent build --model openai/gpt-5.3-codex
+python scripts/run_github_issues_to_opencode.py --repo owner/repo --limit 1
+```
+
+**With OpenCode:**
+```bash
+python scripts/run_github_issues_to_opencode.py --repo owner/repo --limit 1 --runner opencode --agent build --model openai/gpt-4o
 ```
 
 Workflow per issue:
 
 1. Creates a new branch from current branch (`--branch-prefix`, default `issue-fix`)
-2. Runs `opencode run` with issue title/body context
+2. Runs the AI agent with issue title/body context
 3. On changes, creates commit
 4. Pushes issue branch to `origin`
 5. Creates PR back to the original base branch
 
 Useful options:
 
+- `--runner claude|opencode` to select the AI agent runner (default: `claude`)
 - `--state open|closed|all`
 - `--include-empty` to process issues with empty body
 - `--stop-on-error` to stop on first failed run
-- `--dry-run` to preview without executing `opencode`
-- `--model provider/model` to override model
+- `--dry-run` to preview without executing the agent
+- `--model model-name` to override model (e.g. `claude-sonnet-4-6` for Claude, `openai/gpt-4o` for OpenCode)
+- `--agent name` agent name for OpenCode (ignored when using Claude)
 - `--branch-prefix prefix` to customize fix branch names
 
 If `--repo` is not provided, script tries to detect repository from current `gh` context.

--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -88,16 +88,28 @@ def build_prompt(issue: dict) -> str:
     )
 
 
-def run_agent(issue: dict, agent: str, model: str | None, dry_run: bool) -> int:
+def run_agent(
+    issue: dict,
+    runner: str,
+    agent: str,
+    model: str | None,
+    dry_run: bool,
+) -> int:
     prompt = build_prompt(issue)
-    command = ["opencode", "run", "--agent", agent]
-    if model:
-        command.extend(["--model", model])
-    command.append(prompt)
+
+    if runner == "claude":
+        command = ["claude", "-p", prompt]
+        if model:
+            command.extend(["--model", model])
+    else:
+        command = ["opencode", "run", "--agent", agent]
+        if model:
+            command.extend(["--model", model])
+        command.append(prompt)
 
     if dry_run:
         print(
-            f"[dry-run] Would run: {' '.join(command[:5])} ... for issue #{issue['number']}"
+            f"[dry-run] Would run: {' '.join(command[:4])} ... for issue #{issue['number']}"
         )
         return 0
 
@@ -172,7 +184,7 @@ def open_pr(
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Fetch GitHub issues with gh and run opencode agent for each issue body."
+        description="Fetch GitHub issues with gh and run an AI agent for each issue body."
     )
     parser.add_argument(
         "--repo", help="GitHub repo in owner/name format. Defaults to current gh repo."
@@ -181,8 +193,14 @@ def main() -> int:
     parser.add_argument(
         "--limit", type=int, default=10, help="Maximum number of issues to process."
     )
-    parser.add_argument("--agent", default="build", help="Opencode agent name.")
-    parser.add_argument("--model", help="Optional model override for opencode.")
+    parser.add_argument(
+        "--runner",
+        default="claude",
+        choices=["claude", "opencode"],
+        help="AI agent runner to use (default: claude).",
+    )
+    parser.add_argument("--agent", default="build", help="Opencode agent name (only used with --runner opencode).")
+    parser.add_argument("--model", help="Optional model override. For Claude: e.g. claude-sonnet-4-6. For OpenCode: e.g. openai/gpt-4o.")
     parser.add_argument(
         "--branch-prefix",
         default="issue-fix",
@@ -199,7 +217,7 @@ def main() -> int:
         help="Stop after first failed agent run.",
     )
     parser.add_argument(
-        "--dry-run", action="store_true", help="Print actions without running opencode."
+        "--dry-run", action="store_true", help="Print actions without running the agent."
     )
     args = parser.parse_args()
 
@@ -235,7 +253,11 @@ def main() -> int:
             )
 
             exit_code = run_agent(
-                issue=issue, agent=args.agent, model=args.model, dry_run=args.dry_run
+                issue=issue,
+                runner=args.runner,
+                agent=args.agent,
+                model=args.model,
+                dry_run=args.dry_run,
             )
             if exit_code != 0:
                 raise RuntimeError(

--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -108,8 +108,9 @@ def run_agent(
         command.append(prompt)
 
     if dry_run:
+        shown = [part if part != prompt else "<prompt>" for part in command]
         print(
-            f"[dry-run] Would run: {' '.join(command[:4])} ... for issue #{issue['number']}"
+            f"[dry-run] Would run: {' '.join(shown)} for issue #{issue['number']}"
         )
         return 0
 

--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -98,7 +98,7 @@ def run_agent(
     prompt = build_prompt(issue)
 
     if runner == "claude":
-        command = ["claude", "-p", prompt]
+        command = ["claude", "--dangerously-skip-permissions", "-p", prompt]
         if model:
             command.extend(["--model", model])
     else:

--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -53,6 +53,25 @@ def fetch_issues(repo: str, state: str, limit: int) -> list[dict]:
     return issues
 
 
+def fetch_issue(repo: str, number: int) -> dict:
+    output = run_capture(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,url",
+        ]
+    )
+    issue = json.loads(output)
+    if not isinstance(issue, dict):
+        raise RuntimeError(f"Unexpected response fetching issue #{number}")
+    return issue
+
+
 def current_branch() -> str:
     return run_capture(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
 
@@ -189,6 +208,9 @@ def main() -> int:
     parser.add_argument(
         "--repo", help="GitHub repo in owner/name format. Defaults to current gh repo."
     )
+    parser.add_argument(
+        "--issue", type=int, help="Process a single issue by number, ignoring --limit and --state."
+    )
     parser.add_argument("--state", default="open", choices=["open", "closed", "all"])
     parser.add_argument(
         "--limit", type=int, default=10, help="Maximum number of issues to process."
@@ -225,7 +247,10 @@ def main() -> int:
         ensure_clean_worktree()
         base_branch = current_branch()
         repo = args.repo or detect_repo()
-        issues = fetch_issues(repo=repo, state=args.state, limit=args.limit)
+        if args.issue is not None:
+            issues = [fetch_issue(repo=repo, number=args.issue)]
+        else:
+            issues = fetch_issues(repo=repo, state=args.state, limit=args.limit)
     except Exception as exc:  # noqa: BLE001
         print(f"Error: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
 feat(runner): add Claude Code as default AI runner with --runner flag

  - Add --runner claude|opencode flag (default: claude)
  - Claude runner invokes `claude --dangerously-skip-permissions -p <prompt>`
  - Add --issue <number> to target a single issue via `gh issue view`
  - Mask full prompt text in dry-run output with <prompt> placeholder
  - Update README and add .claude/ to .gitignore

  The branch includes two distinct things (Claude runner support + the --issue flag), but since they landed together
  they read naturally as one cohesive feature: upgrading the tool from OpenCode-only to a pluggable runner with Claude
  as the default.