### PR TITLE
Ignore local OpenCode workspace artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 .DS_Store
 
 .claude/
+.opencode/
+opencode.jsonc


### PR DESCRIPTION
## Summary
- add `.opencode/` and `opencode.jsonc` to `.gitignore` so local OpenCode config/state stays out of commits
- keep team defaults in repo unchanged while allowing per-developer local setup