### PR TITLE
Fix issue #48: initialize force override state

### DIFF
--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -1949,6 +1949,28 @@ def main() -> int:
                 print(f"PR #{pr_number_arg} is not open (state: {pr_state}); skipping.")
                 return 0
 
+            recovered_pr_state: dict | None = None
+            try:
+                pr_comments = fetch_issue_comments(repo=repo, issue_number=pr_number_arg)
+                recovered_pr_state, pr_state_warnings = select_latest_parseable_orchestration_state(
+                    comments=pr_comments,
+                    source_label=f"pr #{pr_number_arg}",
+                )
+                for warning in pr_state_warnings:
+                    print(f"Warning: {warning}", file=sys.stderr)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    "Warning: unable to recover orchestration state from "
+                    f"PR #{pr_number_arg} comments: {exc}",
+                    file=sys.stderr,
+                )
+            if recovered_pr_state is not None:
+                prefix = "[dry-run] " if args.dry_run else ""
+                print(
+                    f"{prefix}Recovered orchestration state context: "
+                    f"{format_recovered_state_context(recovered_pr_state)}"
+                )
+
             failure_stage = "fetch_review_feedback"
             threads = fetch_pr_review_threads(repo=repo, number=pr_number_arg)
             conversation_comments = fetch_pr_conversation_comments(
@@ -2046,6 +2068,14 @@ def main() -> int:
                 review_items=review_items,
                 linked_issues=linked_issues,
             )
+            if (
+                recovered_pr_state is not None
+                and str(recovered_pr_state.get("status") or "") == "failed"
+            ):
+                prompt = append_recovered_context_to_prompt(
+                    prompt,
+                    build_recovered_failure_context_note(recovered_pr_state),
+                )
 
             failure_stage = "agent_run"
             exit_code = run_agent_with_prompt(
@@ -2179,6 +2209,7 @@ def main() -> int:
             recovered_state: dict | None = None
             mode = "issue-flow"
             mode_reason = "batch issue processing"
+            force_override_applied = False
             skip_agent_run = False
             state_target_type = "issue"
             state_target_number = issue["number"]

--- a/tests/test_orchestration_state_recovery.py
+++ b/tests/test_orchestration_state_recovery.py
@@ -69,6 +69,58 @@ class OrchestrationStateRecoveryTests(unittest.TestCase):
         self.assertEqual(len(warnings), 1)
         self.assertIn("ignoring malformed orchestration state comment", warnings[0])
 
+    def test_main_issue_flow_without_recovered_state_does_not_require_force_override(self) -> None:
+        args = argparse.Namespace(
+            repo="owner/repo",
+            issue=47,
+            pr=None,
+            from_review_comments=False,
+            state="open",
+            limit=10,
+            runner="opencode",
+            agent="build",
+            model=None,
+            agent_timeout_seconds=900,
+            agent_idle_timeout_seconds=None,
+            opencode_auto_approve=False,
+            branch_prefix="issue-fix",
+            include_empty=False,
+            stop_on_error=False,
+            fail_on_existing=False,
+            force_issue_flow=False,
+            sync_reused_branch=True,
+            sync_strategy="rebase",
+            dir=".",
+            local_config="local-config.json",
+            dry_run=True,
+            pr_followup_branch_prefix=None,
+            post_pr_summary=False,
+        )
+        issue = {
+            "number": 47,
+            "title": "Support current-branch or stacked execution mode",
+            "body": "Implement stacked execution",
+            "url": "https://example/issues/47",
+        }
+
+        with (
+            patch("scripts.run_github_issues_to_opencode.parse_args", return_value=args),
+            patch("scripts.run_github_issues_to_opencode.ensure_clean_worktree"),
+            patch("scripts.run_github_issues_to_opencode.detect_default_branch", return_value="main"),
+            patch("scripts.run_github_issues_to_opencode.fetch_issue", return_value=issue),
+            patch("scripts.run_github_issues_to_opencode.find_open_pr_for_issue", return_value=None),
+            patch("scripts.run_github_issues_to_opencode.fetch_issue_comments", return_value=[]),
+            patch("scripts.run_github_issues_to_opencode.prepare_issue_branch", return_value="created"),
+            patch("scripts.run_github_issues_to_opencode.run_agent", return_value=0),
+            patch("scripts.run_github_issues_to_opencode.has_changes", return_value=False),
+            patch("scripts.run_github_issues_to_opencode.ensure_pr", return_value=("created", "")),
+            patch("sys.stdout", new_callable=io.StringIO) as stdout_mock,
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Selected mode: issue-flow", stdout_mock.getvalue())
+
     def test_main_issue_flow_skips_waiting_for_author_by_default(self) -> None:
         args = argparse.Namespace(
             repo="owner/repo",


### PR DESCRIPTION
## Summary
- Initializes the issue-flow force override flag so default runs do not crash before the agent starts.
- Restores direct PR-mode recovery context logging and failed-context prompt propagation.
- Adds regression coverage for default issue-flow without recovered state.

## Validation
- `python3 -m unittest tests/test_orchestration_state_recovery.py`
- `python3 -m unittest discover -s tests -p 'test_*.py'`

Blocks/unblocks: #47, #7