### PR TITLE
Add retrospectives for orchestration session

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Script can run in two modes:
 
 Memo link: https://www.notion.so/Hacker-Sprint-1-33f2db4c860e8064a657e199b4578f66
 
+## Retrospectives
+
+Session retrospectives live in [`retro/`](retro/). They capture lessons from orchestration runs, including worker behavior, blocker handling, PR validation gaps, and follow-up improvements for the autonomous orchestrator loop.
+
 - `gh` (GitHub CLI) authenticated (`gh auth status`)
 - Python 3.10+
 - `claude` (Claude Code CLI) — default runner

--- a/retro/orchestrator-meta-task-retro.md
+++ b/retro/orchestrator-meta-task-retro.md
@@ -1,0 +1,184 @@
+# Retro: сессия как мета-задача для оркестратора
+
+## Главный вывод
+
+Вся сессия фактически была ручным исполнением одной большой orchestration-задачи:
+
+> Двигай roadmap к Northstar, выбирай следующие issues, запускай worker’ов, проверяй PR, merge’и готовое, заводи blockers, resume’ь после blockers.
+
+Это не обычная implementation task для worker-а. Это responsibility будущего autonomous orchestrator controller.
+
+## Почему задача была плохо декомпозирована
+
+Команда “продолжай делать следующие задачи” на практике включала много разных обязанностей:
+
+- выбрать next issue из roadmap/open issues;
+- проверить текущее состояние GitHub issues/PRs;
+- запустить worker с правильной моделью;
+- дождаться результата;
+- проверить PR diff, tests, mergeability;
+- решить: merge, retry, comment, split или blocker;
+- создать blocker issue при системной проблеме;
+- переключиться на blocker;
+- после blocker вернуться к original issue;
+- поддерживать branch context и state comments;
+- не доверять agent summary без проверки фактического diff.
+
+Это workflow/control-plane задача, а не единичная coding задача.
+
+## Что показала сессия
+
+### Worker хорошо справляется с узкими задачами
+
+Codex Spark и другие workers были полезны, когда задача была локальной и хорошо ограниченной:
+
+- обновить docs;
+- добавить небольшой шаблон;
+- обработать конкретный PR-review comment;
+- исправить небольшой isolated behavior.
+
+### Worker хуже справляется с широкими задачами
+
+Широкие задачи вроде #11 и #61 дали плохие результаты:
+
+- #11 Jira tracker support — PR #76 остался scaffold-only;
+- #61 presets/retry policy — зависания/timeouts и partial changes;
+- review retry не гарантировал meaningful progress.
+
+Вывод: для широких задач нужен decomposition layer, а не просто другой worker.
+
+## Что должен делать оркестратор автоматически
+
+### 1. Task decomposition
+
+Если issue слишком широкая, оркестратор должен разбивать её на sub-issues.
+
+Пример для #11:
+
+1. `--tracker` parser/config only;
+2. Jira env validation only;
+3. Jira single issue fetch;
+4. Jira list/search fetch;
+5. branch/commit naming for Jira keys;
+6. README/tests.
+
+Пример для #61:
+
+1. presets config only;
+2. retry max attempts only;
+3. escalation policy only;
+4. docs/tests.
+
+### 2. Acceptance-aware validation
+
+Оркестратор не должен считать PR готовым только потому, что PR создан и mergeable.
+
+Нужно проверять:
+
+- changed files against acceptance criteria;
+- tests/docs requested by issue;
+- whether required files exist in PR diff;
+- whether agent-created files остались untracked.
+
+Пример #12:
+
+- Acceptance criteria: `docs/jira-issue-template.md` exists.
+- Actual PR #80 files: only `README.md`.
+- Оркестратор должен был автоматически пометить PR incomplete.
+
+### 3. Worker output skepticism
+
+Agent summary нельзя считать source of truth.
+
+Нужно сверять summary с фактами:
+
+```bash
+gh pr diff <PR> --name-only
+git status --short --branch
+python3 -m unittest discover -s tests -p 'test_*.py'
+```
+
+Если agent говорит “добавил tests”, но PR diff tests не содержит — это failure или blocker.
+
+### 4. Blocker loop
+
+Сессия вручную реализовала blocker loop:
+
+1. Обнаружили, что #12 incomplete.
+2. Поняли, что причина системная: new files не staging’ятся.
+3. Создали blocker #81.
+4. Зафиксировали связь с original #12 / PR #80.
+5. Должны после #81 resume’нуть #12.
+
+Это должно быть встроенным поведением оркестратора.
+
+### 5. Safe staging model
+
+Оркестратор должен поддерживать intentional new files без риска случайно закоммитить старый мусор.
+
+Нужная модель:
+
+1. Снять baseline untracked перед agent run.
+2. После agent run вычислить новые untracked.
+3. В commit включить:
+   - tracked modifications/deletions;
+   - new untracked files, появившиеся после baseline.
+4. Не включать pre-existing untracked.
+5. После commit fail/warn, если expected new files остались untracked.
+
+### 6. Retry/split/switch policy
+
+Если worker дважды выдаёт scaffold-only PR или зависает:
+
+- split issue;
+- tighten prompt;
+- switch model/agent;
+- mark `needs-human-review`;
+- create blocker if failure is systemic.
+
+Сейчас эти решения принимались вручную.
+
+## GitHub уже почти является state machine
+
+Сессия показала, что GitHub artifacts подходят как orchestration state:
+
+- issues = tasks;
+- PRs = implementation artifacts;
+- comments = append-only state log;
+- labels = failure/blocker markers;
+- branches = execution context;
+- PR review comments = feedback channel.
+
+Недостаёт controller logic поверх этого.
+
+## Northstar insight
+
+Northstar MVP — это не просто:
+
+> агент пишет код по issue.
+
+Более точная формулировка:
+
+> оркестратор управляет графом задач, PRs, blockers, retries, checks и acceptance criteria до достижения verified outcome.
+
+Worker — это executor. Orchestrator — это controller.
+
+## Практический вывод
+
+Следующие engineering investments должны быть направлены не только на capabilities worker-а, а на orchestration loop:
+
+1. baseline/new untracked tracking;
+2. acceptance-aware PR validation;
+3. automatic blocker creation and resume;
+4. automatic issue splitting for broad tasks;
+5. retry/escalation policy;
+6. stronger PR-review completion checks;
+7. explicit worker trust boundary.
+
+## Summary
+
+Эта сессия была полезна именно потому, что вручную проявила будущий control loop. Почти каждый ручной шаг можно превратить в deterministic orchestration behavior.
+
+Главный урок:
+
+> Нам нужен не только более сильный worker, а более строгий orchestrator, который декомпозирует, проверяет, блокирует, resume’ит и не доверяет agent summary без фактической проверки.

--- a/retro/runner-staging-retro.md
+++ b/retro/runner-staging-retro.md
@@ -1,0 +1,101 @@
+# Retro: запуск blocker #81 и точки улучшения
+
+## Что произошло
+
+- Создан blocker #81: runner не коммитит intentional new files, потому что использует или использовал подход вроде `git add -u`.
+- Запуск был начат командой:
+
+```bash
+python3 scripts/run_github_issues_to_opencode.py \
+  --repo podlodka-ai-club/steam-hammer \
+  --issue 81 \
+  --runner opencode \
+  --agent build \
+  --model openai/gpt-5.3-codex-spark \
+  --opencode-auto-approve \
+  --agent-idle-timeout-seconds 900
+```
+
+- Runner создал ветку:
+
+```text
+issue-fix/81-fix-runner-staging-so-intentional-new-fi
+```
+
+- Codex Spark начал exploration:
+  - сделал `Glob "*"`;
+  - сделал grep по `git add -u|git add --update|git add`;
+  - получил `0 matches`.
+- После этого запуск был abort’нут пользователем.
+
+## Главные проблемы
+
+1. **#12 показал реальный баг runner’а**
+   - Агент создал `docs/jira-issue-template.md`.
+   - Но PR #80 включил только `README.md`.
+   - Новый файл остался untracked локально.
+   - Значит runner/commit path не умеет безопасно включать intentional new files.
+
+2. **PR validation не поймал неполный результат**
+   - PR #80 был `MERGEABLE/CLEAN`, но не удовлетворял acceptance criteria.
+   - Проверка “PR mergeable + tests pass” недостаточна.
+   - Нужно минимум проверять residual untracked files после agent run.
+
+3. **Codex Spark начал с неудачного поиска**
+   - Он искал literal `git add -u`, но получил 0 matches.
+   - Возможные причины:
+     - код уже изменился после fast-forward main;
+     - staging logic переехала/переименована;
+     - нужно искать `commit_changes`, `stage`, `git`, `add`, `run_command([...])`, а не только exact string.
+
+4. **Issue #81 недостаточно указывает кодовую точку**
+   - В issue описан симптом, но нет точного файла/функции.
+   - Для агента лучше сразу указать:
+     - где находится commit/staging logic;
+     - что нужно сравнить baseline untracked до agent run и после.
+
+## Точки улучшения runner’а
+
+1. **Baseline untracked tracking**
+   - Перед agent run сохранить список untracked файлов.
+   - После agent run вычислить новые untracked файлы.
+   - Коммитить:
+     - modified/deleted tracked files;
+     - newly created files, которых не было в baseline.
+   - Не коммитить pre-existing unrelated untracked.
+
+2. **Fail/warn on residual untracked after commit**
+   - После commit перед PR:
+     - если остались новые untracked файлы, созданные agent’ом — fail или comment blocker.
+   - Это бы сразу поймало #12.
+
+3. **PR content validation**
+   - Перед merge проверять changed files against acceptance criteria хотя бы вручную или heuristic.
+   - Для #12 должно было быть очевидно:
+     - expected: `docs/jira-issue-template.md`;
+     - actual PR files: only `README.md`.
+
+4. **Better issue prompts for blockers**
+   - В blocker issue добавлять:
+     - observed branch/PR;
+     - exact missing file;
+     - suspected function/path;
+     - suggested algorithm.
+   - Это снизит шанс, что Spark уйдёт в пустой grep.
+
+5. **Agent search strategy**
+   - Если grep по exact phrase дал 0 matches, agent должен автоматически искать broader terms:
+     - `commit_changes`;
+     - `run_command`;
+     - `git`;
+     - `stage`;
+     - `has_changes`;
+     - `status --porcelain`.
+   - Запуск остановился до такой адаптации.
+
+## Текущий статус на момент retro
+
+- #11 / PR #76 — open, incomplete, не merge’ить.
+- #12 / PR #80 — open, incomplete, не merge’ить.
+- #81 — blocker, started, но запуск abort’нут до изменений.
+- Локальная ветка после запуска могла остаться на `issue-fix/81-...`; перед продолжением лучше проверить status/branch.

--- a/retro/session-retro-key-observations.md
+++ b/retro/session-retro-key-observations.md
@@ -1,0 +1,267 @@
+# Retro: ключевые наблюдения по всей сессии
+
+## Контекст сессии
+
+Целью сессии было продолжать движение по GitHub issues в `podlodka-ai-club/steam-hammer`, используя GitHub issues/PRs как tracker и `scripts/run_github_issues_to_opencode.py` как основной orchestration runner.
+
+В середине сессии был задан новый предпочтительный worker: **Codex Spark** (`openai/gpt-5.3-codex-spark`) через `opencode` agent `build`.
+
+Основной рабочий паттерн:
+
+```bash
+python3 scripts/run_github_issues_to_opencode.py \
+  --repo podlodka-ai-club/steam-hammer \
+  --issue <N> \
+  --runner opencode \
+  --agent build \
+  --model openai/gpt-5.3-codex-spark \
+  --opencode-auto-approve \
+  --agent-idle-timeout-seconds 900
+```
+
+## Что было успешно завершено
+
+### Core roadmap до Codex Spark
+
+До перехода на Codex Spark уже был закрыт существенный набор задач по Northstar MVP:
+
+- #56 doctor diagnostics → PR #64 merged.
+- #57 project config scaffold → PR #65 merged.
+- #58 initial scope rules → PR #66 merged.
+- #60 workflow command execution → PR #67 merged.
+- #62 GitHub CI status reader → PR #68 merged.
+
+Эти задачи укрепили runner как orchestration tool: диагностика, конфигурация, scope rules, workflow checks, чтение CI статусов.
+
+### #10 image attachments
+
+#10 был реализован через PR #69 и смержен.
+
+Позитивные моменты:
+
+- Codex Spark смог доработать PR-review feedback.
+- Были добавлены docs для image attachment behavior.
+- Полный unittest suite проходил локально перед merge.
+- PR был clean/mergeable и был squash-merged.
+
+Важное наблюдение:
+
+- В логах agent claimed, что добавлен `tests/test_issue_image_support.py`, но merged diff в итоге не содержал этот файл.
+- Это ранний сигнал той же категории проблем, что позже явно проявилась в #12: agent-created new files могут не попадать в commit/PR.
+
+## Что не получилось завершить
+
+### #61 presets/retry policy
+
+#61 несколько раз не дошёл до результата:
+
+- обычный Codex run завис без вывода на 900s;
+- Codex Spark run тоже не завершился в outer timeout, оставив partial uncommitted changes;
+- изменения были отброшены, задача осталась open/failed.
+
+Наблюдение:
+
+- #61 выглядит слишком широкой для текущего runner/worker setup.
+- Её стоит разделить на меньшие issues:
+  1. presets config only;
+  2. retry policy only;
+  3. escalation/failure reporting integration.
+
+### #11 Jira tracker support
+
+#11 был запущен через Codex Spark и создал PR #76, но PR оказался крайне неполным.
+
+Фактический результат PR #76:
+
+- добавлены tracker constants/defaults;
+- добавлены helper functions для issue key normalization;
+- не реализованы acceptance criteria:
+  - нет полноценного `--tracker github|jira` CLI flow;
+  - нет Jira env validation;
+  - нет `fetch_jira_issue` / `fetch_jira_issues`;
+  - нет runtime dispatch;
+  - нет README docs;
+  - нет tests.
+
+Наблюдение:
+
+- Agent repeatedly produced planning summaries instead of finishing implementation.
+- PR-review retry на тот же PR не исправил ситуацию: diff остался scaffold-only.
+- Для таких широких integrations Codex Spark нуждается в более узком issue или более сильном prompt with exact files/functions/tests.
+
+### #12 Jira issue template
+
+#12 был простым docs task и Codex Spark частично справился:
+
+- создал `docs/jira-issue-template.md` локально;
+- обновил README;
+- создал PR #80.
+
+Но PR #80 оказался incomplete:
+
+- в PR попал только `README.md`;
+- `docs/jira-issue-template.md` остался untracked локально;
+- acceptance criteria не выполнены.
+
+Это привело к blocker #81.
+
+## Главный системный баг: intentional new files не попадают в PR
+
+Наиболее важное открытие сессии — runner может терять новые файлы, созданные agent’ом.
+
+Симптомы:
+
+- #12: required file `docs/jira-issue-template.md` создан, но не committed.
+- #10: в output упоминался новый test file, но merged diff его не содержал.
+- После PR creation локально появляются untracked files, которые выглядят как intended artifacts.
+
+Вероятная причина:
+
+- staging path слишком осторожный после #7 и не staging’ит untracked files.
+- Это защищает от случайных pre-existing untracked files, но ломает legitimate agent-created files.
+
+Правильная модель:
+
+1. До agent run сохранить baseline untracked files.
+2. После agent run вычислить new untracked files.
+3. В commit включать:
+   - modified/deleted tracked files;
+   - newly created files, которых не было в baseline.
+4. Не включать pre-existing unrelated untracked files.
+5. После commit проверять residual untracked:
+   - если есть новые files from agent, которые не попали в commit — fail/comment blocker.
+
+## Проблемы с validation перед merge
+
+Сессия показала, что `mergeable + tests pass` недостаточно.
+
+Нужны дополнительные проверки:
+
+### 1. Changed files vs acceptance criteria
+
+Для #12 acceptance criteria явно требовал:
+
+- `docs/jira-issue-template.md` exists.
+
+Но PR files были:
+
+- `README.md` only.
+
+Такой mismatch должен автоматически или полуавтоматически блокировать merge.
+
+### 2. Residual untracked files после runner
+
+Если после runner остаются untracked files — это не всегда мусор.
+Нужно классифицировать:
+
+- pre-existing untracked before run → не трогать;
+- new untracked after run → вероятный intended output или agent mistake;
+- new untracked matching acceptance criteria → blocker, если не included in PR.
+
+### 3. Verify PR diff, not только local test output
+
+Agent output может утверждать, что tests/docs добавлены, но PR diff может отличаться.
+Надо проверять:
+
+```bash
+gh pr diff <N> --name-only
+git diff --stat origin/main...HEAD
+```
+
+## Наблюдения по Codex Spark как worker
+
+Плюсы:
+
+- Хорошо справляется с локальными docs/simple edits.
+- Может реагировать на PR-review comments.
+- Может запускать unittest и валидировать изменения.
+
+Минусы:
+
+- На широких архитектурных задачах часто уходит в exploration/planning.
+- Может заявлять Done, когда PR фактически incomplete.
+- Не всегда замечает, что new files остались untracked.
+- Иногда начинает с слишком узкого поиска (`git add -u`) и не расширяет search strategy после zero matches.
+
+Рекомендации:
+
+- Для Codex Spark давать smaller scoped issues.
+- В issue body добавлять exact suspected functions/files.
+- В PR-review comments указывать explicit missing files/tests/docs.
+- После каждого run проверять PR diff independently.
+
+## Наблюдения по runner orchestration
+
+### Хорошо работает
+
+- Создание branches/PRs.
+- State comments в issues/PRs.
+- Reusing linked PR для PR-review mode.
+- Комментарии с failure/blocked evidence.
+- Merge flow для clean/mergeable PRs.
+
+### Требует улучшения
+
+1. **Commit/staging model**
+   - Нужна поддержка intentional new files.
+
+2. **Completion detection**
+   - Runner считает task processed, если PR создан, даже если acceptance criteria incomplete.
+
+3. **Agent output trust boundary**
+   - Нельзя доверять только тексту agent summary.
+   - Нужно проверять actual diff.
+
+4. **Review retry effectiveness**
+   - PR-review retry может оставить PR почти без изменений.
+   - Нужен критерий “review comment addressed” через diff/expected checks.
+
+5. **Issue splitting**
+   - Большие tasks (#11, #61) надо автоматически предлагать split/blocker subtasks.
+
+## Рекомендованный порядок дальнейших действий
+
+1. **Сначала закрыть #81**
+   - Без fix intentional new files дальнейшие docs/test tasks будут ненадёжны.
+
+2. **После #81 возобновить #12 / PR #80**
+   - Добавить missing `docs/jira-issue-template.md` в PR.
+   - Проверить PR files before merge.
+
+3. **Потом вернуться к #11**
+   - Не пытаться закрыть всё одним PR, если Spark продолжает scaffold-only.
+   - Разбить на подзадачи:
+     - `--tracker` parser/config only;
+     - Jira env validation only;
+     - Jira single issue fetch only;
+     - Jira list/search only;
+     - docs/tests.
+
+4. **#61 оставить split-candidate**
+   - presets и retry/escalation policy лучше делать отдельными small PRs.
+
+## Concrete follow-up checks для каждого будущего PR
+
+Перед merge проверять:
+
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus,statusCheckRollup,closingIssuesReferences
+gh pr diff <N> --name-only
+git status --short --branch
+```
+
+И дополнительно спросить:
+
+- Есть ли required files from acceptance criteria в PR diff?
+- Остались ли untracked files после runner?
+- Совпадает ли agent summary с фактическим diff?
+- Есть ли tests/docs, если они были явно requested?
+
+## Summary
+
+Сессия была продуктивной для core roadmap и #10, но выявила два ключевых системных риска:
+
+1. Runner может создавать PR без intentional new files.
+2. Agent/runner может считать задачу completed по факту PR creation, не проверив acceptance criteria.
+
+Главный следующий engineering improvement — #81: безопасный staging новых файлов через baseline untracked tracking и post-run residual validation.


### PR DESCRIPTION
## Summary
- Add a `retro/` directory with session retrospectives covering runner staging, Codex Spark behavior, and orchestration-loop lessons.
- Link the retrospectives from README so future orchestrator work can reference the findings.

## Validation
- Docs-only change; no tests run.