### PR TITLE
Add planning-only decomposition preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,15 +262,16 @@ Workflow per issue:
 2. Out-of-scope issues are blocked (`status=blocked`, stage=`scope_check`) and get a dedicated scope comment; agent run is skipped unless `--force-reprocess` is set
 3. Pre-checks whether issue should be skipped (linked open PR and/or existing deterministic remote branch)
 4. Chooses a base branch (`default`: repository default branch from GitHub; `current`: currently checked-out branch)
-5. Creates a new issue branch from that base (`--branch-prefix`, default `issue-fix`) or reuses an existing one
-6. For reused branches, syncs with the latest selected base branch before agent run (default: `rebase`)
-7. Extracts image attachment references from issue content (or attachment metadata), downloads available images, and runs the AI agent with title/body context plus image files when present.
-8. On changes, creates commit
-9. Pushes issue branch to `origin`
-10. Reuses an existing open PR for the issue branch when present; otherwise creates one to the selected base branch
-11. Posts append-only orchestration state comments to GitHub issue/PR on key transitions
-12. On per-issue failure (agent, commit/push, PR create, etc.), posts a structured failure report comment to the issue and adds label `auto:agent-failed`
-13. On successful issue completion (or no-op completion), removes label `auto:agent-failed` from that issue if present
+5. Runs planning-only decomposition preflight (`--decompose auto` by default); large tasks get a proposed plan comment and stop before branch/agent execution
+6. Creates a new issue branch from that base (`--branch-prefix`, default `issue-fix`) or reuses an existing one
+7. For reused branches, syncs with the latest selected base branch before agent run (default: `rebase`)
+8. Extracts image attachment references from issue content (or attachment metadata), downloads available images, and runs the AI agent with title/body context plus image files when present.
+9. On changes, creates commit
+10. Pushes issue branch to `origin`
+11. Reuses an existing open PR for the issue branch when present; otherwise creates one to the selected base branch
+12. Posts append-only orchestration state comments to GitHub issue/PR on key transitions
+13. On per-issue failure (agent, commit/push, PR create, etc.), posts a structured failure report comment to the issue and adds label `auto:agent-failed`
+14. On successful issue completion (or no-op completion), removes label `auto:agent-failed` from that issue if present
 
 Workflow in PR review mode:
 
@@ -307,6 +308,14 @@ Scope decision comments:
 - Out-of-scope comment includes decision, reason, forced flag, and timestamp in machine-readable JSON
 - Dry-run prints where scope decision comment would be posted
 
+Planning-only decomposition comments:
+
+- Marker: `<!-- orchestration-decomposition:v1 -->`
+- `--decompose auto` proposes a decomposition plan for large/epic/multi-step issues before starting the agent
+- `--decompose always` forces plan-only behavior for an issue, useful for manual planning
+- `--decompose never` bypasses decomposition preflight and keeps the legacy issue-flow path
+- Existing parseable decomposition comments are treated idempotently and are not duplicated on rerun
+
 Useful options:
 
 - `--runner claude|opencode` to select the AI agent runner (default: `claude`)
@@ -338,6 +347,7 @@ Useful options:
 - `--sync-reused-branch` / `--no-sync-reused-branch` enable or disable reused-branch sync before agent run (default: enabled)
 - `--sync-strategy rebase|merge` choose how to sync a reused branch with selected base (default: `rebase`)
 - `--base default|current` (`--base-branch` alias) choose issue-flow base mode; `current` enables stacked execution from your current branch (opt-in)
+- `--decompose auto|never|always` control planning-only decomposition preflight before issue-flow agent execution (default: `auto`)
 - `--doctor` run preflight diagnostics only (no agent run)
 - `--doctor-smoke-check` in doctor mode, run a lightweight runner CLI smoke check
 

--- a/docs/current-behavior.md
+++ b/docs/current-behavior.md
@@ -65,19 +65,20 @@
    - Изображения извлекаются из тел issue (`![](...)`, `<img src=...>`, прямые URL).
    - По найденным ссылкам создаются локальные файлы в временной директории и добавляются в prompt как входные изображения для Claude через `--image`.
    - Если загрузка изображения падает, это логируется, и обработка продолжается в text-only режиме.
-5. Выбирается/создается рабочая ветка по шаблону `<prefix>/<issue-number>-<slug-title>` (по умолчанию prefix: `issue-fix`).
-6. Для переиспользованной ветки может выполняться синхронизация с базой (по умолчанию включена).
-7. Запускается агент с issue-контекстом.
-8. Если изменений нет:
+5. Выполняется planning-only decomposition preflight (`--decompose auto` по умолчанию): большие/epic/multi-step задачи получают proposed plan comment и останавливаются до запуска агента.
+6. Выбирается/создается рабочая ветка по шаблону `<prefix>/<issue-number>-<slug-title>` (по умолчанию prefix: `issue-fix`).
+7. Для переиспользованной ветки может выполняться синхронизация с базой (по умолчанию включена).
+8. Запускается агент с issue-контекстом.
+9. Если изменений нет:
    - обычно commit/PR пропускаются;
    - исключение: если ветка была синхронизирована и изменена только синком, эти изменения пушатся и PR обновляется.
-9. Если изменения есть: commit `Fix issue #N: <title>`, push, затем создание или переиспользование PR.
-10. На ключевых переходах публикуются state-комментарии в issue:
+10. Если изменения есть: commit `Fix issue #N: <title>`, push, затем создание или переиспользование PR.
+11. На ключевых переходах публикуются state-комментарии в issue:
     - `in-progress` перед запуском агента (когда известен branch context);
     - `ready-for-review` после создания/переиспользования PR;
     - `failed` при ошибках (stage/error/next_action);
     - `waiting-for-author`, если изменений нет.
-11. После успешного/no-op завершения для processed issue скрипт пытается снять label `auto:agent-failed`, если он был поставлен раньше.
+12. После успешного/no-op завершения для processed issue скрипт пытается снять label `auto:agent-failed`, если он был поставлен раньше.
 
 После обработки issue скрипт возвращается на базовую ветку (кроме `dry-run`).
 
@@ -176,6 +177,7 @@
 - `--sync-reused-branch` / `--no-sync-reused-branch`: включить/выключить синхронизацию переиспользованных веток;
 - `--sync-strategy rebase|merge`: стратегия синхронизации переиспользованной ветки;
 - `--base default|current` (`--base-branch`): выбор базовой ветки для issue-flow (стабильная default-ветка или stacked запуск от текущей ветки);
+- `--decompose auto|never|always`: planning-only decomposition preflight перед issue-flow agent run; `auto` предлагает план для больших задач, `always` форсирует plan-only режим, `never` отключает preflight;
 - `--allow-pr-branch-switch`: в PR-mode разрешает переключить текущий worktree на target PR branch;
 - `--isolate-worktree`: в PR-mode запускает работу во временном worktree без переключения текущей ветки;
 - `--dry-run`: печать планируемых действий без выполнения.
@@ -191,6 +193,7 @@
 - отсутствуют actionable review comments -> успешный выход без запуска агента;
 - issue body пустой и нет `--include-empty` и нет распознанных image-ссылок -> issue пропускается;
 - batch issue с linked open PR или deterministic remote branch -> skip по умолчанию;
+- issue-flow с найденной большой/epic/multi-step задачей при `--decompose auto|always` -> публикуется `<!-- orchestration-decomposition:v1 -->` plan comment, state `waiting-for-author` stage `decomposition_plan`, агент не запускается;
 - PR-mode из нецелевой ветки без `--allow-pr-branch-switch` или `--isolate-worktree` -> ошибка safeguard;
 - если агент не внес изменения и не было sync-only обновления -> commit/push/PR пропускаются.
 

--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -40,12 +40,14 @@ BUILTIN_DEFAULTS = {
     "sync_reused_branch": True,
     "sync_strategy": "rebase",
     "base_branch": "default",
+    "decompose": "auto",
     "dir": ".",
 }
 
 ORCHESTRATION_STATE_MARKER = "<!-- orchestration-state:v1 -->"
 AGENT_FAILURE_REPORT_MARKER = "<!-- orchestration-agent-failure:v1 -->"
 SCOPE_DECISION_MARKER = "<!-- orchestration-scope:v1 -->"
+DECOMPOSITION_PLAN_MARKER = "<!-- orchestration-decomposition:v1 -->"
 AGENT_FAILURE_LABEL_NAME = "auto:agent-failed"
 AGENT_FAILURE_LABEL_COLOR = "B60205"
 AGENT_FAILURE_LABEL_DESCRIPTION = "Automation run failed for this issue"
@@ -808,6 +810,68 @@ def select_latest_parseable_orchestration_state(
             "comment_id": comment.get("id"),
             "payload": payload,
             "status": normalize_orchestration_state_status(payload),
+        }
+        if latest is None or created_at >= str(latest.get("created_at") or ""):
+            latest = candidate
+
+    return latest, warnings
+
+
+def parse_decomposition_plan_comment_body(body: str) -> tuple[dict | None, str | None]:
+    if DECOMPOSITION_PLAN_MARKER not in body:
+        return None, None
+
+    after_marker = body.split(DECOMPOSITION_PLAN_MARKER, maxsplit=1)[1].strip()
+    if not after_marker:
+        return None, "marker found but payload is empty"
+
+    fenced_matches = re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", after_marker, flags=re.DOTALL)
+    candidates = fenced_matches if fenced_matches else [after_marker]
+
+    parse_errors: list[str] = []
+    for candidate in candidates:
+        try:
+            return _first_json_object(candidate), None
+        except (ValueError, json.JSONDecodeError) as exc:
+            parse_errors.append(str(exc))
+
+    if parse_errors:
+        return None, parse_errors[-1]
+    return None, "unable to parse decomposition payload"
+
+
+def select_latest_parseable_decomposition_plan(
+    comments: list[dict],
+    source_label: str,
+) -> tuple[dict | None, list[str]]:
+    latest: dict | None = None
+    warnings: list[str] = []
+
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+
+        body = str(comment.get("body") or "")
+        payload, error = parse_decomposition_plan_comment_body(body)
+        if payload is None:
+            if error:
+                created_at = str(comment.get("created_at") or "unknown-time")
+                url = str(comment.get("html_url") or "")
+                context = f" at {url}" if url else ""
+                warnings.append(
+                    f"ignoring malformed decomposition comment in {source_label}"
+                    f" ({created_at}){context}: {error}"
+                )
+            continue
+
+        created_at = str(comment.get("created_at") or "")
+        candidate = {
+            "source": source_label,
+            "created_at": created_at,
+            "url": str(comment.get("html_url") or ""),
+            "comment_id": comment.get("id"),
+            "payload": payload,
+            "status": str(payload.get("status") or "").strip().lower(),
         }
         if latest is None or created_at >= str(latest.get("created_at") or ""):
             latest = candidate
@@ -1863,6 +1927,162 @@ def build_issue_scope_skip_comment(issue_number: int, reason: str, forced: bool)
         f"{next_action}\n\n"
         f"{SCOPE_DECISION_MARKER}\n"
         f"```json\n{json.dumps(payload, ensure_ascii=True, indent=2)}\n```"
+    )
+
+
+DECOMPOSITION_KEYWORDS = {
+    "epic",
+    "roadmap",
+    "architecture",
+    "daemon",
+    "multi-provider",
+    "decomposition",
+    "linked subtask",
+    "subtask",
+    "multiple pr",
+    "multi-step",
+    "large",
+}
+
+
+def _issue_body_lines(issue: dict) -> list[str]:
+    body = str(issue.get("body") or "")
+    return [line.strip() for line in body.splitlines() if line.strip()]
+
+
+def _issue_scope_bullets(issue: dict) -> list[str]:
+    bullets: list[str] = []
+    for line in _issue_body_lines(issue):
+        normalized = line.strip()
+        if normalized.startswith(('-', '*')):
+            item = normalized[1:].strip()
+            if item:
+                bullets.append(item)
+    return bullets
+
+
+def assess_issue_decomposition_need(issue: dict) -> dict:
+    title = str(issue.get("title") or "")
+    body = str(issue.get("body") or "")
+    combined = f"{title}\n{body}".lower()
+    bullets = _issue_scope_bullets(issue)
+    reasons: list[str] = []
+
+    if len(body) >= 1200:
+        reasons.append("long_body")
+    if len(bullets) >= 6:
+        reasons.append("many_bullets")
+
+    matched_keywords = sorted(keyword for keyword in DECOMPOSITION_KEYWORDS if keyword in combined)
+    if matched_keywords:
+        reasons.append("large_scope_keywords")
+
+    acceptance_like = sum(
+        1
+        for line in _issue_body_lines(issue)
+        if any(token in line.lower() for token in ["acceptance", "success criteria", "scope", "goal"])
+    )
+    if acceptance_like >= 3:
+        reasons.append("multiple_planning_sections")
+
+    return {
+        "needs_decomposition": bool(reasons),
+        "reasons": reasons,
+        "matched_keywords": matched_keywords,
+        "body_length": len(body),
+        "bullet_count": len(bullets),
+    }
+
+
+def build_decomposition_plan_payload(issue: dict, assessment: dict) -> dict:
+    bullets = _issue_scope_bullets(issue)
+    proposed_children: list[dict] = []
+    source_items = bullets[:5]
+    if not source_items:
+        source_items = [
+            "Clarify scope and acceptance criteria",
+            "Implement the smallest safe slice",
+            "Validate behavior and update tracker state",
+        ]
+
+    for index, item in enumerate(source_items, start=1):
+        title = item.rstrip(".")
+        proposed_children.append(
+            {
+                "title": title[:120],
+                "order": index,
+                "depends_on": [] if index == 1 else [index - 1],
+                "acceptance": [f"{title} is completed and validated."],
+            }
+        )
+
+    return {
+        "status": "proposed",
+        "parent_issue": issue.get("number"),
+        "reason": assessment.get("reasons", []),
+        "matched_keywords": assessment.get("matched_keywords", []),
+        "proposed_children": proposed_children,
+        "next_action": "approve_plan_or_rerun_with_decompose_never",
+        "timestamp": utc_now_iso(),
+    }
+
+
+def format_decomposition_plan_comment(payload: dict) -> str:
+    reasons = payload.get("reason") if isinstance(payload.get("reason"), list) else []
+    children = payload.get("proposed_children")
+    if not isinstance(children, list):
+        children = []
+
+    reason_lines = "\n".join(f"- `{reason}`" for reason in reasons) or "- `manual`"
+    child_lines: list[str] = []
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        order = child.get("order")
+        title = str(child.get("title") or "Untitled child task")
+        deps = child.get("depends_on") if isinstance(child.get("depends_on"), list) else []
+        deps_text = f"; depends on: {', '.join(str(dep) for dep in deps)}" if deps else ""
+        child_lines.append(f"{order}. {title}{deps_text}")
+    children_text = "\n".join(child_lines) or "No child tasks proposed."
+
+    return (
+        "Decomposition plan proposed\n\n"
+        "Status: `needs-decomposition`\n\n"
+        "Reason:\n"
+        f"{reason_lines}\n\n"
+        "Proposed child tasks:\n"
+        f"{children_text}\n\n"
+        "Recommended next action: approve/edit this plan, or rerun with `--decompose never` "
+        "to intentionally bypass planning-only decomposition.\n\n"
+        f"{DECOMPOSITION_PLAN_MARKER}\n"
+        f"```json\n{json.dumps(payload, ensure_ascii=True, indent=2)}\n```"
+    )
+
+
+def post_decomposition_plan_comment(
+    repo: str,
+    issue_number: int,
+    payload: dict,
+    dry_run: bool,
+) -> None:
+    if dry_run:
+        print(
+            f"[dry-run] Would post decomposition plan to issue #{issue_number}: "
+            f"children={len(payload.get('proposed_children') or [])}"
+        )
+        return
+
+    run_command(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--body",
+            format_decomposition_plan_comment(payload),
+        ]
     )
 
 
@@ -3065,6 +3285,7 @@ def validate_local_config(config: dict, config_path: str) -> dict:
         "sync_reused_branch",
         "sync_strategy",
         "base_branch",
+        "decompose",
     }
 
     unsupported = sorted(set(config) - supported_keys)
@@ -3151,6 +3372,11 @@ def validate_local_config(config: dict, config_path: str) -> dict:
         if config["base_branch"] not in {"default", "current"}:
             raise RuntimeError("Local config key 'base_branch' must be one of: default, current")
         validated["base_branch"] = config["base_branch"]
+
+    if "decompose" in config:
+        if config["decompose"] not in {"auto", "never", "always"}:
+            raise RuntimeError("Local config key 'decompose' must be one of: auto, never, always")
+        validated["decompose"] = config["decompose"]
 
     return validated
 
@@ -3658,6 +3884,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--decompose",
+        default=BUILTIN_DEFAULTS["decompose"],
+        choices=["auto", "never", "always"],
+        help=(
+            "Planning-only decomposition preflight for issue-flow: 'auto' proposes a plan "
+            "for large tasks before agent execution, 'never' disables it, and 'always' "
+            "forces a plan-only run."
+        ),
+    )
+    parser.add_argument(
         "--dir",
         default=BUILTIN_DEFAULTS["dir"],
         help="Path to the local git repository to operate on. Defaults to the current directory.",
@@ -3738,6 +3974,7 @@ def main() -> int:
     isolate_worktree = bool(getattr(args, "isolate_worktree", False))
     post_pr_summary = bool(getattr(args, "post_pr_summary", False))
     base_branch_mode = str(getattr(args, "base_branch", BUILTIN_DEFAULTS["base_branch"]))
+    decompose_mode = str(getattr(args, "decompose", BUILTIN_DEFAULTS["decompose"]))
 
     if force_reprocess:
         skip_if_pr_exists = False
@@ -4518,6 +4755,65 @@ def main() -> int:
 
             if body_image_reason:
                 print(f"Issue #{issue['number']} {body_image_reason}")
+
+            if mode == "issue-flow" and decompose_mode != "never":
+                failure_stage = "decomposition_preflight"
+                assessment = assess_issue_decomposition_need(issue)
+                should_plan = decompose_mode == "always" or bool(
+                    assessment.get("needs_decomposition")
+                )
+                if should_plan:
+                    issue_comments = fetch_issue_comments(repo=repo, issue_number=issue["number"])
+                    latest_plan, plan_warnings = select_latest_parseable_decomposition_plan(
+                        comments=issue_comments,
+                        source_label=f"issue #{issue['number']}",
+                    )
+                    for warning in plan_warnings:
+                        print(f"Warning: {warning}", file=sys.stderr)
+
+                    if latest_plan is not None:
+                        prefix = "[dry-run] " if args.dry_run else ""
+                        print(
+                            f"{prefix}Decomposition plan already exists for issue #{issue['number']} "
+                            f"({latest_plan.get('url') or 'no url'}); skipping duplicate plan."
+                        )
+                        processed += 1
+                        continue
+
+                    payload = build_decomposition_plan_payload(issue=issue, assessment=assessment)
+                    post_decomposition_plan_comment(
+                        repo=repo,
+                        issue_number=issue["number"],
+                        payload=payload,
+                        dry_run=args.dry_run,
+                    )
+                    safe_post_orchestration_state_comment(
+                        repo=repo,
+                        target_type="issue",
+                        target_number=issue["number"],
+                        dry_run=args.dry_run,
+                        state=build_orchestration_state(
+                            status="waiting-for-author",
+                            task_type="issue",
+                            issue_number=issue["number"],
+                            pr_number=None,
+                            branch=issue_branch,
+                            base_branch=base_branch if base_branch else None,
+                            runner=args.runner,
+                            agent=args.agent,
+                            model=args.model,
+                            attempt=1,
+                            stage="decomposition_plan",
+                            next_action="approve_plan_or_rerun_with_decompose_never",
+                            error="Task requires planning-only decomposition before implementation",
+                        ),
+                    )
+                    processed += 1
+                    print(
+                        f"Issue #{issue['number']} needs decomposition; posted planning-only plan "
+                        "and stopped before agent execution."
+                    )
+                    continue
 
             processed += 1
 

--- a/tests/test_decomposition_planning.py
+++ b/tests/test_decomposition_planning.py
@@ -1,0 +1,127 @@
+import json
+import os
+import tempfile
+import unittest
+
+from scripts.run_github_issues_to_opencode import (
+    BUILTIN_DEFAULTS,
+    DECOMPOSITION_PLAN_MARKER,
+    assess_issue_decomposition_need,
+    build_decomposition_plan_payload,
+    format_decomposition_plan_comment,
+    parse_args,
+    parse_decomposition_plan_comment_body,
+    select_latest_parseable_decomposition_plan,
+)
+
+
+class DecompositionPlanningTests(unittest.TestCase):
+    def test_small_issue_does_not_need_decomposition(self) -> None:
+        issue = {
+            "number": 1,
+            "title": "Fix typo",
+            "body": "Correct the README spelling mistake.",
+        }
+
+        assessment = assess_issue_decomposition_need(issue)
+
+        self.assertFalse(assessment["needs_decomposition"])
+        self.assertEqual(assessment["reasons"], [])
+
+    def test_large_epic_issue_needs_decomposition(self) -> None:
+        issue = {
+            "number": 99,
+            "title": "Epic: Task decomposition and linked subtask management",
+            "body": "\n".join(
+                [
+                    "## Goal",
+                    "Allow the orchestrator to split large work into smaller linked tracker tasks.",
+                    "## Scope",
+                    "- Add a planning/decomposition phase.",
+                    "- Create child/linked issues.",
+                    "- Record dependencies.",
+                    "- Execute subtasks in dependency order.",
+                    "- Roll progress up to the parent task.",
+                ]
+            ),
+        }
+
+        assessment = assess_issue_decomposition_need(issue)
+
+        self.assertTrue(assessment["needs_decomposition"])
+        self.assertIn("large_scope_keywords", assessment["reasons"])
+
+    def test_plan_comment_round_trips_machine_payload(self) -> None:
+        issue = {
+            "number": 99,
+            "title": "Epic: Decompose work",
+            "body": "- First slice\n- Second slice",
+        }
+        assessment = {
+            "reasons": ["large_scope_keywords"],
+            "matched_keywords": ["epic"],
+        }
+
+        payload = build_decomposition_plan_payload(issue=issue, assessment=assessment)
+        body = format_decomposition_plan_comment(payload)
+        parsed, error = parse_decomposition_plan_comment_body(body)
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["status"], "proposed")
+        self.assertEqual(parsed["parent_issue"], 99)
+        self.assertIn(DECOMPOSITION_PLAN_MARKER, body)
+
+    def test_latest_decomposition_plan_is_selected(self) -> None:
+        first = {
+            "status": "proposed",
+            "parent_issue": 99,
+            "proposed_children": [],
+        }
+        second = {
+            "status": "proposed",
+            "parent_issue": 99,
+            "proposed_children": [{"title": "Latest", "order": 1}],
+        }
+        comments = [
+            {
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://example.test/old",
+                "body": f"{DECOMPOSITION_PLAN_MARKER}\n```json\n{json.dumps(first)}\n```",
+            },
+            {
+                "created_at": "2026-01-02T00:00:00Z",
+                "html_url": "https://example.test/new",
+                "body": f"{DECOMPOSITION_PLAN_MARKER}\n```json\n{json.dumps(second)}\n```",
+            },
+        ]
+
+        latest, warnings = select_latest_parseable_decomposition_plan(
+            comments=comments,
+            source_label="issue #99",
+        )
+
+        self.assertEqual(warnings, [])
+        self.assertIsNotNone(latest)
+        self.assertEqual(latest["url"], "https://example.test/new")
+        self.assertEqual(latest["payload"]["proposed_children"][0]["title"], "Latest")
+
+    def test_decompose_cli_and_local_config_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.mkdir(os.path.join(tmpdir, ".git"))
+            args = parse_args(["--dir", tmpdir])
+            self.assertEqual(args.decompose, BUILTIN_DEFAULTS["decompose"])
+
+            config_path = os.path.join(tmpdir, "local-config.json")
+            with open(config_path, "w", encoding="utf-8") as config_file:
+                json.dump({"decompose": "never"}, config_file)
+
+            configured_args = parse_args(["--dir", tmpdir])
+            cli_args = parse_args(["--dir", tmpdir, "--decompose", "always"])
+
+        self.assertEqual(configured_args.decompose, "never")
+        self.assertEqual(cli_args.decompose, "always")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_config_precedence.py
+++ b/tests/test_local_config_precedence.py
@@ -22,6 +22,7 @@ class LocalConfigPrecedenceTests(unittest.TestCase):
         self.assertEqual(args.sync_reused_branch, BUILTIN_DEFAULTS["sync_reused_branch"])
         self.assertEqual(args.sync_strategy, BUILTIN_DEFAULTS["sync_strategy"])
         self.assertEqual(args.base_branch, BUILTIN_DEFAULTS["base_branch"])
+        self.assertEqual(args.decompose, BUILTIN_DEFAULTS["decompose"])
 
     def test_local_config_overrides_built_in_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -40,6 +41,7 @@ class LocalConfigPrecedenceTests(unittest.TestCase):
                         "sync_reused_branch": False,
                         "sync_strategy": "merge",
                         "base_branch": "current",
+                        "decompose": "never",
                     },
                     config_file,
                 )
@@ -56,6 +58,7 @@ class LocalConfigPrecedenceTests(unittest.TestCase):
         self.assertFalse(args.sync_reused_branch)
         self.assertEqual(args.sync_strategy, "merge")
         self.assertEqual(args.base_branch, "current")
+        self.assertEqual(args.decompose, "never")
 
     def test_cli_flags_override_local_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Add `--decompose auto|never|always` planning-only preflight for large issue-flow tasks.
- Post machine-readable `orchestration-decomposition:v1` plan comments and stop before agent execution when decomposition is needed.
- Document behavior and add focused tests for heuristics, plan parsing/idempotency, and config/CLI defaults.

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`\n- `python3 -m unittest tests.test_decomposition_planning tests.test_local_config_precedence`\n\nCloses #102