### PR TITLE
Add daemon mode orchestration retros

### DIFF
--- a/retro/2026-04-28-daemon-mode-next2-retro.md
+++ b/retro/2026-04-28-daemon-mode-next2-retro.md
@@ -1,0 +1,65 @@
+# Retro: daemon-mode execution for next North Star tasks
+
+Date: 2026-04-28
+
+## Scope
+
+We tried to execute the next two large North Star tasks through daemon mode instead of direct per-issue runner calls:
+
+- #153: Add operator status summary for orchestration runs.
+- #152: Add dedicated conflict-recovery mode for reused branches.
+
+The daemon was launched from a fresh clone with `openai/gpt-5.4`, `--max-cycles`, and bounded `--limit` settings.
+
+## Outcome
+
+The implementation outcome was good:
+
+- #153 was implemented by the daemon-launched worker and merged as PR #154.
+- #152 was implemented by the daemon-launched worker and merged as PR #155.
+- Both implementation PRs were verified by the worker before merge.
+- The final open PR list was empty.
+
+The orchestration outcome was mixed:
+
+- Daemon mode successfully launched real worker execution and produced mergeable PRs.
+- The first bounded daemon run did not process two distinct tasks as expected.
+- Cycle 2 reprocessed #153 instead of moving to #152, because #153 still had an open PR / ready-for-review state and `--force-reprocess` made it eligible again.
+- #152 had to be processed by a second bounded daemon run after #154 was merged.
+
+## What went well
+
+- Daemon mode was usable for real repository work, not just dry-run smoke testing.
+- Status checkpoints made the long session understandable: done/current/next/problems/manual actions were easy to report between batches.
+- The worker handled sizeable changes in central orchestration code and converged after intermediate test failures.
+- PR gating was safe: clean PRs were inspected and merged sequentially.
+- The new `orchestrator status` surface from #153 immediately improves operator visibility.
+- The new `--conflict-recovery-only` mode from #152 directly addresses a pain point from the previous North Star batch.
+
+## What was painful
+
+- `--max-cycles 2 --limit 2 --force-reprocess` did not mean “process two distinct tasks”.
+- The daemon selected #153 twice, which made the batch less predictable and required manual intervention to continue with #152.
+- The daemon currently lacks an obvious single-pass batch mode for “take the next N tasks once each”.
+- Large central runner edits still create long test cycles and large diffs.
+
+## Unexpected behavior
+
+Created follow-up issue #156 for daemon batch progression:
+
+- expected: a bounded daemon run with two eligible issues processes two distinct issues;
+- observed: daemon reprocessed the first issue in the same invocation;
+- likely cause: current selection/reprocess semantics do not remember tasks already handled during the current daemon invocation.
+
+## Assessment
+
+The implementation work itself went well. Both requested North Star tasks landed and improved the product in meaningful ways.
+
+The daemon-mode experiment was successful enough to keep using, but it exposed an important scheduler/selection gap. Daemon can execute work end-to-end, but for operator-controlled batches it needs better per-invocation progress semantics.
+
+## Follow-ups
+
+1. Fix #156 so bounded daemon batches can progress across distinct tasks.
+2. Consider a documented `single-pass-batch` mode or equivalent default for `--max-cycles N --limit N`.
+3. Keep using the new status command during future long-running daemon sessions.
+4. Continue reducing central-runner change size through modularization before larger Go-core migration work.

--- a/retro/2026-04-28-northstar-batch-retro.md
+++ b/retro/2026-04-28-northstar-batch-retro.md
@@ -23,6 +23,7 @@ Date: 2026-04-28
 - Sequential merge + rerun loop worked despite heavy overlap.
 - Final verification caught a real regression in merge policy normalization before stopping.
 - Provider-qualified model string `openai/gpt-5.4` was used successfully.
+- The session showed that a mostly autonomous orchestration loop is viable: the orchestrator can manage batches of runner/CLI executions, inspect PR/issue state between batches, decide what to merge or rerun, and continue with limited user involvement.
 
 ## What was painful
 
@@ -34,6 +35,7 @@ Date: 2026-04-28
 - Worker reruns sometimes re-implemented or extended issue work instead of doing only branch conflict recovery.
 - Full Python suite takes about 5 minutes and emits noisy mocked `gh` warnings.
 - Runner output around rebase failures and merge fallback is verbose and hard to scan.
+- During the long-running orchestration loop, the user did not get enough periodic status checkpoints. It was hard to see what was done, what was currently running, what would happen next, and where the next checkpoint was.
 
 ## Process improvements
 
@@ -45,6 +47,7 @@ Date: 2026-04-28
 - Add a dedicated conflict-recovery mode that only syncs/rebases and resolves conflicts, without asking the worker to revisit the entire issue scope.
 - Add a post-batch verification issue/checklist automatically when a large batch finishes.
 - Suppress or isolate expected mocked `gh` warnings in tests so real failures are easier to spot.
+- Treat periodic batch status as part of the orchestrator contract for long sessions: between batches of CLI/runner executions, summarize done/current/next, touched issues/PRs, blockers, and the next checkpoint. This should not happen after every command, but it should happen often enough that a user can ask for status and understand the session state.
 
 ## Action items
 
@@ -52,3 +55,4 @@ Date: 2026-04-28
 2. Create a task to reduce full Python suite noise and/or split slow verification modes.
 3. Create a task for smarter reused-branch conflict recovery.
 4. Consider splitting the large Python runner into smaller modules to reduce conflict pressure.
+5. Track periodic batch status as a product/agent improvement: GitHub issue #141.


### PR DESCRIPTION
## Summary
- Add a daemon-mode retro for the #153/#152 North Star batch.
- Update the earlier North Star batch retro with periodic status observations and issue #141 follow-up.

## Verification
- Not run; markdown-only changes.