### PR TITLE
Fix issue #274: Fix Windows Go build blockers from #225

### DIFF
--- a/internal/cli/detached.go
+++ b/internal/cli/detached.go
@@ -13,7 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -341,14 +340,7 @@ func processRunning(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}
-	err := syscall.Kill(pid, 0)
-	if err == nil {
-		return true, nil
-	}
-	if errors.Is(err, syscall.ESRCH) {
-		return false, nil
-	}
-	return false, err
+	return processAlive(pid)
 }
 
 func detachedWorkerReports(configuredRoot string) ([]detachedWorkerReport, error) {

--- a/internal/cli/process_unix.go
+++ b/internal/cli/process_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package cli
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func processAlive(pid int) (bool, error) {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/cli/process_windows.go
+++ b/internal/cli/process_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+const windowsProcessQueryLimitedInformation = 0x1000
+const windowsStillActive = 259
+const windowsErrorInvalidParameter syscall.Errno = 87
+
+func configureDetachedProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+func processAlive(pid int) (bool, error) {
+	handle, err := syscall.OpenProcess(windowsProcessQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windowsErrorInvalidParameter) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer syscall.CloseHandle(handle)
+
+	var code uint32
+	if err := syscall.GetExitCodeProcess(handle, &code); err != nil {
+		return false, err
+	}
+	return code == windowsStillActive, nil
+}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 type Runner interface {
@@ -66,7 +65,7 @@ func (ExecDetachedStarter) Start(req DetachedRequest) (DetachedProcess, error) {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureDetachedProcess(cmd)
 
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()


### PR DESCRIPTION
## Summary
- Implements Windows-safe process helpers for detached worker process setup and liveness checks.
- Preserves Unix `Setpgid`/`Kill(pid, 0)` behavior behind `!windows` build tags.
- Adds Windows `CREATE_NEW_PROCESS_GROUP` and `OpenProcess`/`GetExitCodeProcess` equivalents.

## Verification
- `go test ./...`
- `python3 -m unittest discover -s tests -q`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/steam-hammer-cli-windows.test.exe ./internal/cli`
- `GOOS=windows GOARCH=amd64 go build -o /tmp/orchestrator-windows.exe ./cmd/orchestrator`

Closes #274
Closes #225