### PR TITLE
Fix issue #276: Fix Windows subprocess UTF-8 decoding from #238

### DIFF
--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -1396,7 +1396,7 @@ def preview_autonomous_issue_queue(issues: list[dict], start_index: int, limit: 
 
 
 def run_capture(command: list[str]) -> str:
-    result = subprocess.run(command, capture_output=True, text=True)
+    result = subprocess.run(command, capture_output=True, **_subprocess_text_kwargs())
     if result.returncode != 0:
         stderr = result.stderr.strip()
         raise RuntimeError(f"Command failed: {' '.join(command)}\n{stderr}")
@@ -1410,7 +1410,7 @@ def run_command(command: list[str]) -> None:
 
 
 def command_succeeds(command: list[str]) -> bool:
-    result = subprocess.run(command, capture_output=True, text=True)
+    result = subprocess.run(command, capture_output=True, **_subprocess_text_kwargs())
     return result.returncode == 0
 
 
@@ -1420,7 +1420,13 @@ def run_check_command(
     env: dict[str, str] | None = None,
 ) -> tuple[bool, str, str, int]:
     try:
-        result = subprocess.run(command, capture_output=True, text=True, cwd=cwd, env=env)
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            cwd=cwd,
+            env=env,
+            **_subprocess_text_kwargs(),
+        )
     except FileNotFoundError as exc:
         return False, "", str(exc), 127
     return (
@@ -1442,6 +1448,10 @@ def describe_exit_code(return_code: int) -> str:
         return f"terminated by signal {signal_number}"
 
     return f"terminated by {signal_name} ({signal_number})"
+
+
+def _subprocess_text_kwargs() -> dict[str, str | bool]:
+    return {"text": True, "encoding": "utf-8"}
 
 
 def classify_opencode_failure(return_code: int, model: str | None) -> str | None:
@@ -1492,8 +1502,8 @@ def validate_opencode_model_backend(runner: str, model: str | None) -> None:
         result = subprocess.run(
             [ollama_path, "show", local_model],
             capture_output=True,
-            text=True,
             timeout=OLLAMA_PREFLIGHT_TIMEOUT_SECONDS,
+            **_subprocess_text_kwargs(),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
@@ -1706,9 +1716,9 @@ def _run_workflow_shell_command(
         result = subprocess.run(
             ["bash", "-lc", command_text],
             capture_output=True,
-            text=True,
             cwd=cwd,
             env=env,
+            **_subprocess_text_kwargs(),
         )
     except FileNotFoundError as exc:
         raise RuntimeError(
@@ -3144,7 +3154,7 @@ def run_merge_for_pull_request(repo: str, pr_number: int, merge_policy: dict, dr
         )
         return
 
-    result = subprocess.run(command, capture_output=True, text=True)
+    result = subprocess.run(command, capture_output=True, **_subprocess_text_kwargs())
     if result.returncode == 0:
         return
 
@@ -7322,9 +7332,9 @@ def run_agent_with_prompt(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
         bufsize=1,
         cwd=cwd,
+        **_subprocess_text_kwargs(),
     )
 
     line_queue: _queue.Queue[tuple[str, str]] = _queue.Queue()

--- a/tests/test_agent_run_stats.py
+++ b/tests/test_agent_run_stats.py
@@ -218,6 +218,27 @@ class AgentRunStatsTests(unittest.TestCase):
         self.assertEqual(run_stats["tokens_out"], 1400)
         self.assertEqual(run_stats["tokens_total"], 21400)
 
+    def test_run_agent_with_prompt_uses_explicit_utf8_text_encoding(self) -> None:
+        process = self._FakeProcess(stdout_lines=[], stderr_lines=[], poll_results=[0])
+
+        with patch("scripts.run_github_issues_to_opencode.subprocess.Popen", return_value=process) as popen_mock:
+            exit_code = run_agent_with_prompt(
+                prompt="fix it",
+                item_label="issue #91",
+                runner="opencode",
+                agent="build",
+                model=None,
+                dry_run=False,
+                timeout_seconds=900,
+                idle_timeout_seconds=None,
+                opencode_auto_approve=False,
+                track_tokens=False,
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(popen_mock.call_args.kwargs["encoding"], "utf-8")
+        self.assertTrue(popen_mock.call_args.kwargs["text"])
+
     def test_run_agent_with_prompt_stops_when_cost_budget_exceeded(self) -> None:
         process = self._FakeProcess(
             stdout_lines=["Estimated cost: $0.4200\n"],

--- a/tests/test_opencode_failure_diagnostics.py
+++ b/tests/test_opencode_failure_diagnostics.py
@@ -8,8 +8,11 @@ from scripts.run_github_issues_to_opencode import (
     AGENT_FAILURE_LABEL_NAME,
     RECOMMENDED_OPENCODE_MODEL,
     classify_opencode_failure,
+    command_succeeds,
     describe_exit_code,
     ensure_agent_failure_label,
+    run_capture,
+    run_check_command,
     validate_opencode_model_backend,
 )
 
@@ -111,6 +114,45 @@ class ValidateOpenCodeModelBackendTests(unittest.TestCase):
 
         self.assertIn("Timed out after 30s", str(ctx.exception))
         self.assertIn("qwen3.5:2b", str(ctx.exception))
+
+    @patch("scripts.run_github_issues_to_opencode.shutil.which", return_value="/usr/local/bin/ollama")
+    @patch("scripts.run_github_issues_to_opencode.subprocess.run")
+    def test_ollama_show_uses_explicit_utf8_text_encoding(self, run_mock, _which) -> None:
+        run_mock.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        validate_opencode_model_backend(runner="opencode", model="ollama/qwen3.5:2b")
+
+        self.assertEqual(run_mock.call_args.kwargs["encoding"], "utf-8")
+        self.assertTrue(run_mock.call_args.kwargs["text"])
+
+
+class SubprocessUtf8Tests(unittest.TestCase):
+    @patch("scripts.run_github_issues_to_opencode.subprocess.run")
+    def test_run_capture_uses_explicit_utf8_text_encoding(self, run_mock) -> None:
+        run_mock.return_value = SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+        self.assertEqual(run_capture(["gh", "status"]), "ok")
+
+        self.assertEqual(run_mock.call_args.kwargs["encoding"], "utf-8")
+        self.assertTrue(run_mock.call_args.kwargs["text"])
+
+    @patch("scripts.run_github_issues_to_opencode.subprocess.run")
+    def test_command_succeeds_uses_explicit_utf8_text_encoding(self, run_mock) -> None:
+        run_mock.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        self.assertTrue(command_succeeds(["gh", "status"]))
+
+        self.assertEqual(run_mock.call_args.kwargs["encoding"], "utf-8")
+        self.assertTrue(run_mock.call_args.kwargs["text"])
+
+    @patch("scripts.run_github_issues_to_opencode.subprocess.run")
+    def test_run_check_command_uses_explicit_utf8_text_encoding(self, run_mock) -> None:
+        run_mock.return_value = SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        self.assertEqual(run_check_command(["gh", "status"]), (True, "ok", "", 0))
+
+        self.assertEqual(run_mock.call_args.kwargs["encoding"], "utf-8")
+        self.assertTrue(run_mock.call_args.kwargs["text"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Centralizes subprocess text-mode options with explicit UTF-8 encoding.
- Applies UTF-8 decoding to `subprocess.run` helper/workflow paths and the agent `subprocess.Popen` reader-thread path.
- Adds regression tests to guard UTF-8 subprocess usage.

## Verification
- `go test ./...`
- `python3 -m unittest discover -s tests -q`

Closes #276
Closes #238