### PR TITLE
Fix issue #278: Child of #243: Move PR review runtime loop into Go

### DIFF
--- a/docs/current-behavior.md
+++ b/docs/current-behavior.md
@@ -80,7 +80,7 @@
 - daemon issue selection, claim/release comments, session checkpoint wiring и detached worker preparation;
 - detached worker registry/status surfaces и post-batch verification.
 - Python compatibility adapter:
-- `run pr` runtime и review-comments execution loop;
+- `run pr` fallback paths, которые еще не перенесены в Go: `--dry-run`, `--isolate-worktree`, `--detach`, `--post-pr-summary`, follow-up branch mode и conflict-recovery/sync-only варианты;
 - `doctor`, `autodoctor`, `status` и другие еще не перенесенные CLI compatibility surfaces;
 - batch/daemon worker execution paths, которые все еще запускаются через script adapter;
 - issue-path blockers, еще не реализованные в Go: reused branch handling, linked PR reuse internals beyond adapter routing, dedicated conflict-recovery-only runtime.
@@ -95,7 +95,7 @@
 
 ## Что еще не доведено до North Star
 
-- PR review runtime, reused-branch issue runtime и часть autonomous worker execution все еще не перенесены из Python compatibility adapter в Go.
+- Часть PR review runtime уже перенесена в Go для explicit-repo non-isolated execution, но fallback-only режимы все еще живут в Python compatibility adapter вместе с reused-branch issue runtime и частью autonomous worker execution.
 - Нет еще полноценной interactive `resume` поверхности и richer operator UX поверх сохраненного session checkpoint.
 - Нет dedicated conflict-recovery mode, который чинит только branch divergence без полного повторного issue run.
 - Нет обязательного post-batch verification workflow, который сам создает follow-up issue/checklist после крупных merge batches.

--- a/docs/final-smoke-checklist.md
+++ b/docs/final-smoke-checklist.md
@@ -4,8 +4,8 @@ This note records the final bounded smoke coverage for the Go-first runtime boun
 
 ## Boundary Under Test
 
-- Go owns execution-mode selection, fresh-branch `run issue`, daemon selection/claim logic, detached worker surfaces, and post-batch verification wiring.
-- Python is a compatibility adapter for the still-unmigrated runtime paths: `run pr`, reused-branch/conflict-recovery issue paths, and batch/daemon worker execution loops that have not moved to Go yet.
+- Go owns execution-mode selection, fresh-branch `run issue`, the default explicit-repo `run pr` review loop, daemon selection/claim logic, detached worker surfaces, and post-batch verification wiring.
+- Python is a compatibility adapter for the still-unmigrated runtime paths: `run pr` fallback modes (`--dry-run`, isolated worktree, detach, follow-up/conflict-recovery variants), reused-branch/conflict-recovery issue paths, and batch/daemon worker execution loops that have not moved to Go yet.
 - Guardrail: when Go already selected `pr-review`, `run issue` must route to the explicit PR compatibility adapter (`--pr ... --from-review-comments`) instead of delegating the whole issue decision back to `--issue` Python flow.
 
 ## Checklist
@@ -13,7 +13,7 @@ This note records the final bounded smoke coverage for the Go-first runtime boun
 | Scenario | Coverage command | Expected evidence | Result |
 | --- | --- | --- | --- |
 | One-shot issue flow | `go test ./internal/cli -run TestRunIssueUsesGoNativeHappyPath -count=1` | Native issue path completes without Python runner calls. | Passed on 2026-05-01 |
-| PR review flow | `go test ./internal/cli -run 'TestRunIssueRoutesLinkedPRToPRCompatibilityAdapter|TestRunIssueRoutesReadyToMergeRecoveryToPRCompatibilityAdapter|TestRunPRCommandWiresPythonRunner' -count=1` | Go routes linked-PR issue recovery into explicit PR adapter; PR command still uses compatibility adapter. | Passed on 2026-05-01 |
+| PR review flow | `go test ./internal/cli -run 'TestRunPRUsesNativeRuntimeLoopWhenRepoExplicit|TestRunPRCommandAcceptsPythonPRFlags' -count=1` | Explicit-repo PR review runs natively without Python runner calls; compatibility fallback still works for unmigrated PR modes. | Passed on 2026-05-01 |
 | Detached batch flow | `go test ./internal/cli -run 'TestRunBatchDetachStartsOneWorkerPerIssue|TestRunBatchDetachPersistsBatchMetadataForChildWorkers' -count=1` | One worker per issue, isolated state, predictable worker metadata. | Passed on 2026-05-01 |
 | Daemon with `--max-parallel-tasks 3` | `go test ./internal/cli -run TestRunDaemonDetachStartsThreeWorkersWhenRequested -count=1` | Three detached daemon workers are prepared with isolated directories/state. | Passed on 2026-05-01 |
 | Verified merge queue path | `python3 -m unittest tests.test_pr_review_comments_mode tests.test_orchestration_state_recovery -q` | Readiness/merge-result verification reaches `ready-to-merge` and status summaries preserve verification evidence. | Passed on 2026-05-01 |

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -18,6 +18,7 @@ type App struct {
 	clone          BatchClonePreparer
 	daemon         daemonLifecycle
 	issueLifecycle issueLifecycle
+	prLifecycle    prReviewLifecycle
 	agentRunner    issueAgentRunner
 	runtime        runtimeProvider
 }
@@ -33,6 +34,7 @@ func NewApp(out, err io.Writer) *App {
 		clone:          ExecBatchClonePreparer{},
 		daemon:         adapter,
 		issueLifecycle: adapter,
+		prLifecycle:    adapter,
 		agentRunner:    nativeIssueAgentRunner{},
 		runtime:        defaultRuntimeProvider(),
 	}
@@ -56,6 +58,10 @@ func (a *App) SetDaemonLifecycle(lifecycle daemonLifecycle) {
 
 func (a *App) SetIssueLifecycle(lifecycle issueLifecycle) {
 	a.issueLifecycle = lifecycle
+}
+
+func (a *App) SetPRLifecycle(lifecycle prReviewLifecycle) {
+	a.prLifecycle = lifecycle
 }
 
 func (a *App) SetIssueAgentRunner(runner issueAgentRunner) {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -97,8 +97,15 @@ type fakeDaemonLifecycle struct {
 	issue           githublifecycle.Issue
 	defaultBranch   string
 	linkedPR        *githublifecycle.PullRequest
+	pullRequest     githublifecycle.PullRequest
+	pullRequests    []githublifecycle.PullRequest
+	reviewThreads   []githublifecycle.PullRequestReviewThread
+	reviewThreadSeq [][]githublifecycle.PullRequestReviewThread
+	conversation    []githublifecycle.PullRequestConversationComment
+	conversationSeq [][]githublifecycle.PullRequestConversationComment
 	commentsByIssue map[int][]githublifecycle.IssueComment
 	commentBodies   map[int][]string
+	prCommentBodies map[int][]string
 	createdIssues   []githublifecycle.CreateIssueRequest
 	createIssue     githublifecycle.Issue
 	createdPRs      []githublifecycle.CreatePullRequestRequest
@@ -186,6 +193,56 @@ func (f *fakeDaemonLifecycle) CreatePullRequest(_ context.Context, req githublif
 		f.createPRURL = "https://github.com/owner/repo/pull/101"
 	}
 	return f.createPRURL, nil
+}
+
+func (f *fakeDaemonLifecycle) FetchPullRequest(_ context.Context, _ string, number int) (githublifecycle.PullRequest, error) {
+	if f.listErr != nil {
+		return githublifecycle.PullRequest{}, f.listErr
+	}
+	if len(f.pullRequests) > 0 {
+		pr := f.pullRequests[0]
+		f.pullRequests = f.pullRequests[1:]
+		return pr, nil
+	}
+	if f.pullRequest.Number == 0 {
+		f.pullRequest = githublifecycle.PullRequest{Number: number, Title: "Fix review feedback", URL: "https://github.com/owner/repo/pull/" + strconv.Itoa(number), HeadRefName: "feature/pr-" + strconv.Itoa(number), BaseRefName: "main"}
+	}
+	return f.pullRequest, nil
+}
+
+func (f *fakeDaemonLifecycle) CommentOnPullRequest(_ context.Context, _ string, number int, body string) error {
+	if f.commentErr != nil {
+		return f.commentErr
+	}
+	if f.prCommentBodies == nil {
+		f.prCommentBodies = map[int][]string{}
+	}
+	f.prCommentBodies[number] = append(f.prCommentBodies[number], body)
+	return nil
+}
+
+func (f *fakeDaemonLifecycle) ReviewThreadsForPullRequest(_ context.Context, _ string, _ int) ([]githublifecycle.PullRequestReviewThread, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if len(f.reviewThreadSeq) > 0 {
+		threads := f.reviewThreadSeq[0]
+		f.reviewThreadSeq = f.reviewThreadSeq[1:]
+		return append([]githublifecycle.PullRequestReviewThread(nil), threads...), nil
+	}
+	return append([]githublifecycle.PullRequestReviewThread(nil), f.reviewThreads...), nil
+}
+
+func (f *fakeDaemonLifecycle) ConversationCommentsForPullRequest(_ context.Context, _ string, _ int) ([]githublifecycle.PullRequestConversationComment, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if len(f.conversationSeq) > 0 {
+		comments := f.conversationSeq[0]
+		f.conversationSeq = f.conversationSeq[1:]
+		return append([]githublifecycle.PullRequestConversationComment(nil), comments...), nil
+	}
+	return append([]githublifecycle.PullRequestConversationComment(nil), f.conversation...), nil
 }
 
 func (r *recordingBatchClonePreparer) Prepare(sourceDir, targetDir string) (string, error) {
@@ -1367,6 +1424,100 @@ func TestRunPRCommandAcceptsPythonPRFlags(t *testing.T) {
 		t.Fatalf("Run() code = %d, want 0", code)
 	}
 	assertCommand(t, runner, []string{runnerScript, "--pr", "72", "--from-review-comments"})
+}
+
+func TestRunPRUsesNativeRuntimeLoopWhenRepoExplicit(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: ""},
+		{Stdout: " M internal/cli/pr_native.go\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: ""},
+		{Stdout: "[feature/pr-72 abc123] Address review comments for PR #72\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: "pushed\n"},
+	}}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{ExitCode: 0, Stats: agentexec.Stats{ElapsedSeconds: 5}}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue: githublifecycle.Issue{Number: 243, Title: "Parent issue", Body: "Parent issue body", URL: "https://github.com/owner/repo/issues/243", Tracker: githublifecycle.TrackerGitHub},
+		pullRequests: []githublifecycle.PullRequest{
+			{
+				Number:                  72,
+				Title:                   "Move PR review runtime loop into Go",
+				Body:                    "PR description",
+				URL:                     "https://github.com/owner/repo/pull/72",
+				HeadRefName:             "feature/pr-72",
+				BaseRefName:             "main",
+				Author:                  &githublifecycle.Actor{Login: "author"},
+				ClosingIssuesReferences: []githublifecycle.IssueReference{{Number: 243}},
+			},
+			{
+				Number:                  72,
+				Title:                   "Move PR review runtime loop into Go",
+				Body:                    "PR description",
+				URL:                     "https://github.com/owner/repo/pull/72",
+				HeadRefName:             "feature/pr-72",
+				BaseRefName:             "main",
+				Author:                  &githublifecycle.Actor{Login: "author"},
+				ClosingIssuesReferences: []githublifecycle.IssueReference{{Number: 243}},
+			},
+		},
+		reviewThreadSeq: [][]githublifecycle.PullRequestReviewThread{
+			{{
+				Comments: []githublifecycle.PullRequestReviewComment{{
+					Body:   "Please add a regression test",
+					Path:   "internal/cli/pr_native.go",
+					Line:   12,
+					Author: &githublifecycle.Actor{Login: "reviewer"},
+				}},
+			}},
+			{},
+		},
+	}
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueAgentRunner(agent)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetPRLifecycle(lifecycle)
+
+	code := app.Run([]string{"run", "pr", "--id", "72", "--repo", "owner/repo"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 1 {
+		t.Fatalf("agent call count = %d, want 1", agent.callCount)
+	}
+	if got := agent.requests[0].Prompt; !strings.Contains(got, "review_comment") || !strings.Contains(got, "Issue #243") {
+		t.Fatalf("native PR prompt missing review or issue context: %q", got)
+	}
+	if len(lifecycle.prCommentBodies[72]) < 2 {
+		t.Fatalf("PR comments posted = %d, want at least 2", len(lifecycle.prCommentBodies[72]))
+	}
+	lastComment := lifecycle.prCommentBodies[72][len(lifecycle.prCommentBodies[72])-1]
+	state, err := orchestration.ParseOrchestrationStateCommentBody(lastComment)
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody() error = %v", err)
+	}
+	if state == nil || state.Status != orchestration.StatusWaitingForCI {
+		t.Fatalf("final PR state = %#v, want waiting-for-ci", state)
+	}
+	joinedShell := strings.Join(shell.cmds, "\n")
+	if !strings.Contains(joinedShell, "git 'commit' '-m' 'Address review comments for PR #72'") {
+		t.Fatalf("shell commands missing PR commit: %s", joinedShell)
+	}
+	if !strings.Contains(joinedShell, "git 'push' '-u' 'origin' 'feature/pr-72'") {
+		t.Fatalf("shell commands missing PR push: %s", joinedShell)
+	}
 }
 
 func TestRunPRCommandForwardsConflictRecoveryOnly(t *testing.T) {

--- a/internal/cli/command_run.go
+++ b/internal/cli/command_run.go
@@ -1349,6 +1349,19 @@ func (a *App) runPR(ctx context.Context, args []string) int {
 		_, _ = fmt.Fprintln(a.err, "run pr requires --id N")
 		return 2
 	}
+	if code, ok := a.tryRunNativePR(ctx, nativePROptions{
+		prID:                 *id,
+		common:               opts,
+		allowBranchSwitch:    *allowBranchSwitch,
+		isolateWorktree:      *isolateWorktree,
+		postSummary:          *postSummary,
+		followupPrefix:       *followupPrefix,
+		conflictRecoveryOnly: *conflictRecoveryOnly,
+		syncStrategy:         *syncStrategy,
+		detach:               *detach,
+	}); ok {
+		return code
+	}
 
 	pythonArgs := buildPRPythonArgs(a.runtime.RunnerScript(), opts, *id, *allowBranchSwitch, *isolateWorktree, *postSummary, *followupPrefix, *conflictRecoveryOnly, *syncStrategy)
 	if *detach {

--- a/internal/cli/pr_native.go
+++ b/internal/cli/pr_native.go
@@ -1,0 +1,553 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/podlodka-ai-club/steam-hammer/internal/core/agentexec"
+	"github.com/podlodka-ai-club/steam-hammer/internal/core/githublifecycle"
+	"github.com/podlodka-ai-club/steam-hammer/internal/core/orchestration"
+)
+
+const (
+	nativePRDefaultRunner = "opencode"
+	nativePRDefaultAgent  = "review"
+	nativePRDefaultModel  = "openai/gpt-4o"
+)
+
+type prReviewLifecycle interface {
+	FetchPullRequest(ctx context.Context, repo string, number int) (githublifecycle.PullRequest, error)
+	CommentOnPullRequest(ctx context.Context, repo string, number int, body string) error
+	ReviewThreadsForPullRequest(ctx context.Context, repo string, number int) ([]githublifecycle.PullRequestReviewThread, error)
+	ConversationCommentsForPullRequest(ctx context.Context, repo string, number int) ([]githublifecycle.PullRequestConversationComment, error)
+}
+
+type nativePROptions struct {
+	prID                 int
+	common               commonOptions
+	allowBranchSwitch    bool
+	isolateWorktree      bool
+	postSummary          bool
+	followupPrefix       string
+	conflictRecoveryOnly bool
+	syncStrategy         string
+	detach               bool
+}
+
+func (a *App) tryRunNativePR(ctx context.Context, opts nativePROptions) (int, bool) {
+	repo := strings.TrimSpace(*opts.common.repo)
+	if repo == "" {
+		return 0, false
+	}
+	if reason := nativePRFallbackReason(opts); reason != "" {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: falling back to python pr runner: %s\n", reason)
+		return 0, false
+	}
+	if a.prLifecycle == nil || a.issueLifecycle == nil || a.agentRunner == nil {
+		_, _ = fmt.Fprintln(a.err, "orchestrator: falling back to python pr runner: native PR dependencies are not configured")
+		return 0, false
+	}
+	return a.runNativePR(ctx, repo, opts), true
+}
+
+func nativePRFallbackReason(opts nativePROptions) string {
+	if opts.detach {
+		return "--detach is not supported by the Go-native PR path yet"
+	}
+	if *opts.common.dryRun {
+		return "--dry-run is not supported by the Go-native PR path yet"
+	}
+	if opts.isolateWorktree {
+		return "--isolate-worktree is not supported by the Go-native PR path yet"
+	}
+	if opts.postSummary {
+		return "--post-pr-summary is not supported by the Go-native PR path yet"
+	}
+	if strings.TrimSpace(opts.followupPrefix) != "" {
+		return "--pr-followup-branch-prefix is not supported by the Go-native PR path yet"
+	}
+	if opts.conflictRecoveryOnly {
+		return "--conflict-recovery-only is not supported by the Go-native PR path yet"
+	}
+	if strings.TrimSpace(opts.syncStrategy) != "" {
+		return "--sync-strategy is not supported by the Go-native PR path yet"
+	}
+	if strings.TrimSpace(*opts.common.local) != "" {
+		return "--local-config is not supported by the Go-native PR path yet"
+	}
+	if strings.TrimSpace(*opts.common.project) != "" {
+		return "--project-config is not supported by the Go-native PR path yet"
+	}
+	if strings.TrimSpace(*opts.common.preset) != "" {
+		return "--preset is not supported by the Go-native PR path yet"
+	}
+	if tracker := strings.TrimSpace(*opts.common.tracker); tracker != "" && !strings.EqualFold(tracker, githublifecycle.TrackerGitHub) {
+		return "native PR flow currently supports only the GitHub tracker"
+	}
+	if codehost := strings.TrimSpace(*opts.common.codehost); codehost != "" && !strings.EqualFold(codehost, githublifecycle.TrackerGitHub) {
+		return "native PR flow currently supports only the GitHub code host"
+	}
+	return ""
+}
+
+func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions) int {
+	pullRequest, err := a.prLifecycle.FetchPullRequest(ctx, repo, opts.prID)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to fetch PR #%d: %v\n", opts.prID, err)
+		return 1
+	}
+
+	cwd := defaultSourceDir(*opts.common.dir)
+	repoRoot, err := a.gitRepoRoot(ctx, cwd)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to resolve repository root: %v\n", err)
+		return 1
+	}
+	if dirty, err := a.gitHasChanges(ctx, repoRoot); err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to inspect worktree status: %v\n", err)
+		return 1
+	} else if dirty {
+		_, _ = fmt.Fprintln(a.err, "orchestrator: git working tree must be clean before native PR execution")
+		return 1
+	}
+
+	targetBranch := strings.TrimSpace(pullRequest.HeadRefName)
+	if targetBranch == "" {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: PR #%d is missing head branch metadata\n", pullRequest.Number)
+		return 1
+	}
+	activeBranch, err := a.gitCurrentBranch(ctx, repoRoot)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to resolve current branch: %v\n", err)
+		return 1
+	}
+	if activeBranch != targetBranch {
+		if !opts.allowBranchSwitch {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: current branch %q does not match PR branch %q; rerun with --allow-pr-branch-switch or switch branches manually\n", activeBranch, targetBranch)
+			return 1
+		}
+		if _, err := a.runGit(ctx, repoRoot, "checkout", targetBranch); err != nil {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to switch to PR branch %q: %v\n", targetBranch, err)
+			return 1
+		}
+		activeBranch = targetBranch
+	}
+
+	runnerName := fallbackString(strings.TrimSpace(*opts.common.runner), nativePRDefaultRunner)
+	agentName := fallbackString(strings.TrimSpace(*opts.common.agent), nativePRDefaultAgent)
+	modelName := fallbackString(strings.TrimSpace(*opts.common.model), nativePRDefaultModel)
+	maxAttempts := *opts.common.maxTry
+	if maxAttempts <= 0 {
+		maxAttempts = 1
+	}
+	linkedIssues := a.loadLinkedIssueContext(ctx, repo, pullRequest)
+
+	postState := func(state orchestration.TrackedState) {
+		if err := a.safePostPRState(ctx, repo, pullRequest.Number, state); err != nil {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post state for PR #%d: %v\n", pullRequest.Number, err)
+		}
+	}
+	failedState := func(attempt int, stage, nextAction, message string) orchestration.TrackedState {
+		return orchestration.TrackedState{
+			Status:     orchestration.StatusFailed,
+			TaskType:   "pr",
+			PR:         intPtr(pullRequest.Number),
+			Branch:     activeBranch,
+			BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+			Runner:     runnerName,
+			Agent:      agentName,
+			Model:      modelName,
+			Attempt:    attempt,
+			Stage:      stage,
+			NextAction: nextAction,
+			Error:      message,
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		}
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		reviewItems, reviewStats, err := a.fetchNativePRReviewFeedback(ctx, repo, pullRequest)
+		if err != nil {
+			postState(failedState(attempt, "review_feedback", "inspect_review_feedback", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to collect review feedback for PR #%d: %v\n", pullRequest.Number, err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(a.out, "Review prompt sources: %s\n", orchestration.FormatReviewFeedbackStats(reviewStats))
+		if len(reviewItems) == 0 {
+			postState(orchestration.TrackedState{
+				Status:     orchestration.StatusWaitingForAuthor,
+				TaskType:   "pr",
+				PR:         intPtr(pullRequest.Number),
+				Branch:     activeBranch,
+				BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+				Runner:     runnerName,
+				Agent:      agentName,
+				Model:      modelName,
+				Attempt:    attempt,
+				Stage:      "review_feedback",
+				NextAction: "await_new_review_comments",
+				Error:      "No actionable review comments found",
+				Timestamp:  time.Now().UTC().Format(time.RFC3339),
+			})
+			_, _ = fmt.Fprintf(a.out, "No actionable review comments found for PR #%d; nothing to do.\n", pullRequest.Number)
+			return 0
+		}
+
+		postState(orchestration.TrackedState{
+			Status:     orchestration.StatusInProgress,
+			TaskType:   "pr",
+			PR:         intPtr(pullRequest.Number),
+			Branch:     activeBranch,
+			BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+			Runner:     runnerName,
+			Agent:      agentName,
+			Model:      modelName,
+			Attempt:    attempt,
+			Stage:      "agent_run",
+			NextAction: "wait_for_agent_result",
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		})
+
+		preRunUntracked, err := a.gitUntrackedFiles(ctx, repoRoot)
+		if err != nil {
+			postState(failedState(attempt, "agent_run", "inspect_git_status", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to capture untracked baseline: %v\n", err)
+			return 1
+		}
+		prompt := buildNativePRReviewPrompt(pullRequest, reviewItems, linkedIssues, *opts.common.lightweight || strings.EqualFold(strings.TrimSpace(*opts.common.mode), "lightweight"))
+		result, err := a.agentRunner.Run(ctx, fmt.Sprintf("PR #%d", pullRequest.Number), agentexec.Request{
+			Runner:              runnerName,
+			Prompt:              prompt,
+			Agent:               agentName,
+			Model:               modelName,
+			OpenCodeAutoApprove: *opts.common.autoYes,
+			Cwd:                 repoRoot,
+			Timeout:             durationSeconds(*opts.common.timeout),
+			IdleTimeout:         durationSeconds(*opts.common.idleTime),
+			Stdout:              a.out,
+			Stderr:              a.err,
+		})
+		if err != nil {
+			message := err.Error()
+			if result != nil && result.ClarificationRequest != nil {
+				message = stringValue(result.ClarificationRequest["reason"], message)
+			}
+			postState(failedState(attempt, "agent_run", "inspect_agent_failure", message))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: agent failed for PR #%d: %v\n", pullRequest.Number, err)
+			return 1
+		}
+		if result != nil && result.ExitCode != 0 {
+			message := fmt.Sprintf("Agent exited with code %d", result.ExitCode)
+			postState(failedState(attempt, "agent_run", "inspect_agent_failure", message))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: %s for PR #%d\n", message, pullRequest.Number)
+			return 1
+		}
+		if result != nil && result.ClarificationRequest != nil {
+			question := stringValue(result.ClarificationRequest["question"], "")
+			reason := stringValue(result.ClarificationRequest["reason"], question)
+			if question != "" {
+				if err := a.safePostPRComment(ctx, repo, pullRequest.Number, orchestration.BuildClarificationRequestComment(question, reason)); err != nil {
+					_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post clarification request for PR #%d: %v\n", pullRequest.Number, err)
+				}
+				postState(orchestration.TrackedState{
+					Status:     orchestration.StatusWaitingForAuthor,
+					TaskType:   "pr",
+					PR:         intPtr(pullRequest.Number),
+					Branch:     activeBranch,
+					BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+					Runner:     runnerName,
+					Agent:      agentName,
+					Model:      modelName,
+					Attempt:    attempt,
+					Stage:      "agent_run",
+					NextAction: "await_author_reply",
+					Error:      reason,
+					Timestamp:  time.Now().UTC().Format(time.RFC3339),
+					Stats:      statsMap(result.Stats),
+				})
+				_, _ = fmt.Fprintf(a.out, "Paused PR #%d for clarification: %s\n", pullRequest.Number, question)
+				return 0
+			}
+		}
+
+		hasChanges, err := a.gitHasChanges(ctx, repoRoot)
+		if err != nil {
+			postState(failedState(attempt, "commit_push", "inspect_git_status", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to inspect post-agent changes: %v\n", err)
+			return 1
+		}
+		if !hasChanges {
+			postState(orchestration.TrackedState{
+				Status:     orchestration.StatusWaitingForAuthor,
+				TaskType:   "pr",
+				PR:         intPtr(pullRequest.Number),
+				Branch:     activeBranch,
+				BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+				Runner:     runnerName,
+				Agent:      agentName,
+				Model:      modelName,
+				Attempt:    attempt,
+				Stage:      "post_agent_check",
+				NextAction: "await_more_feedback_or_manual_changes",
+				Error:      "Agent produced no repository changes",
+				Timestamp:  time.Now().UTC().Format(time.RFC3339),
+				Stats:      statsMap(result.Stats),
+			})
+			_, _ = fmt.Fprintf(a.out, "No changes detected for PR #%d; skipping commit and push\n", pullRequest.Number)
+			return 0
+		}
+
+		if err := a.assertNativeGitContext(ctx, repoRoot, activeBranch, "commit PR review changes"); err != nil {
+			postState(failedState(attempt, "commit_push", "restore_branch_context", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: %v\n", err)
+			return 1
+		}
+		if err := a.gitStageIssueChanges(ctx, repoRoot, preRunUntracked); err != nil {
+			postState(failedState(attempt, "commit_push", "inspect_stage_failure", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to stage PR changes: %v\n", err)
+			return 1
+		}
+		if err := a.gitCommit(ctx, repoRoot, nativePRCommitTitle(pullRequest)); err != nil {
+			postState(failedState(attempt, "commit_push", "inspect_commit_failure", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to commit PR changes: %v\n", err)
+			return 1
+		}
+		if err := a.gitPushBranch(ctx, repoRoot, activeBranch); err != nil {
+			postState(failedState(attempt, "commit_push", "inspect_push_failure", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push PR branch %q: %v\n", activeBranch, err)
+			return 1
+		}
+
+		postState(orchestration.TrackedState{
+			Status:     orchestration.StatusWaitingForCI,
+			TaskType:   "pr",
+			PR:         intPtr(pullRequest.Number),
+			Branch:     activeBranch,
+			BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+			Runner:     runnerName,
+			Agent:      agentName,
+			Model:      modelName,
+			Attempt:    attempt,
+			Stage:      "pr_update",
+			NextAction: "wait_for_ci",
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+			Stats:      statsMap(result.Stats),
+		})
+
+		updatedPR, err := a.prLifecycle.FetchPullRequest(ctx, repo, pullRequest.Number)
+		if err != nil {
+			postState(failedState(attempt, "review_feedback", "inspect_review_feedback", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to refresh PR #%d after push: %v\n", pullRequest.Number, err)
+			return 1
+		}
+		pullRequest = updatedPR
+		remainingItems, remainingStats, err := a.fetchNativePRReviewFeedback(ctx, repo, pullRequest)
+		if err != nil {
+			postState(failedState(attempt, "review_feedback", "inspect_review_feedback", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to refresh review feedback for PR #%d: %v\n", pullRequest.Number, err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(a.out, "Review prompt sources: %s\n", orchestration.FormatReviewFeedbackStats(remainingStats))
+		if len(remainingItems) == 0 {
+			_, _ = fmt.Fprintf(a.out, "Done. Processed PR #%d with no remaining actionable review items after attempt %d.\n", pullRequest.Number, attempt)
+			return 0
+		}
+		if attempt >= maxAttempts {
+			postState(orchestration.TrackedState{
+				Status:     orchestration.StatusBlocked,
+				TaskType:   "pr",
+				PR:         intPtr(pullRequest.Number),
+				Branch:     activeBranch,
+				BaseBranch: strings.TrimSpace(pullRequest.BaseRefName),
+				Runner:     runnerName,
+				Agent:      agentName,
+				Model:      modelName,
+				Attempt:    attempt,
+				Stage:      "review_feedback",
+				NextAction: "manual_review_follow_up_required",
+				Error:      fmt.Sprintf("%d actionable review items remain after %d/%d attempts", len(remainingItems), attempt, maxAttempts),
+				Timestamp:  time.Now().UTC().Format(time.RFC3339),
+				Stats:      statsMap(result.Stats),
+			})
+			_, _ = fmt.Fprintf(a.out, "PR #%d still has %d actionable review items after %d/%d attempts; blocking for manual follow-up.\n", pullRequest.Number, len(remainingItems), attempt, maxAttempts)
+			return 0
+		}
+		_, _ = fmt.Fprintf(a.out, "PR #%d still has %d actionable review items after attempt %d; continuing review feedback loop (%d/%d).\n", pullRequest.Number, len(remainingItems), attempt, attempt+1, maxAttempts)
+	}
+
+	return 0
+}
+
+func (a *App) fetchNativePRReviewFeedback(ctx context.Context, repo string, pullRequest githublifecycle.PullRequest) ([]orchestration.ReviewFeedbackItem, orchestration.ReviewFeedbackStats, error) {
+	threads, err := a.prLifecycle.ReviewThreadsForPullRequest(ctx, repo, pullRequest.Number)
+	if err != nil {
+		return nil, orchestration.ReviewFeedbackStats{}, err
+	}
+	conversationComments, err := a.prLifecycle.ConversationCommentsForPullRequest(ctx, repo, pullRequest.Number)
+	if err != nil {
+		return nil, orchestration.ReviewFeedbackStats{}, err
+	}
+	normalizedThreads := make([]orchestration.ReviewThread, 0, len(threads))
+	for _, thread := range threads {
+		comments := make([]orchestration.ReviewThreadComment, 0, len(thread.Comments))
+		for _, comment := range thread.Comments {
+			author := ""
+			if comment.Author != nil {
+				author = comment.Author.Login
+			}
+			comments = append(comments, orchestration.ReviewThreadComment{
+				Body:     comment.Body,
+				Path:     comment.Path,
+				Line:     comment.Line,
+				Outdated: comment.Outdated,
+				URL:      comment.URL,
+				Author:   author,
+			})
+		}
+		normalizedThreads = append(normalizedThreads, orchestration.ReviewThread{
+			Resolved: thread.IsResolved,
+			Outdated: thread.IsOutdated,
+			Comments: comments,
+		})
+	}
+	normalizedConversation := make([]orchestration.ConversationComment, 0, len(conversationComments))
+	for _, comment := range conversationComments {
+		normalizedConversation = append(normalizedConversation, orchestration.ConversationComment{
+			Author: comment.Author,
+			Body:   comment.Body,
+			URL:    comment.URL,
+		})
+	}
+	normalizedReviews := make([]orchestration.PullRequestReview, 0, len(pullRequest.Reviews))
+	for _, review := range pullRequest.Reviews {
+		normalizedReviews = append(normalizedReviews, orchestration.PullRequestReview{
+			State:       review.State,
+			SubmittedAt: review.SubmittedAt,
+			AuthorLogin: review.AuthorLogin,
+			Body:        review.Body,
+			URL:         review.URL,
+		})
+	}
+	prAuthor := ""
+	if pullRequest.Author != nil {
+		prAuthor = pullRequest.Author.Login
+	}
+	items, stats := orchestration.NormalizeReviewFeedback(normalizedThreads, normalizedReviews, normalizedConversation, prAuthor)
+	return items, stats, nil
+}
+
+func (a *App) loadLinkedIssueContext(ctx context.Context, repo string, pullRequest githublifecycle.PullRequest) []githublifecycle.Issue {
+	if len(pullRequest.ClosingIssuesReferences) == 0 {
+		return nil
+	}
+	linked := make([]githublifecycle.Issue, 0, len(pullRequest.ClosingIssuesReferences))
+	for _, reference := range pullRequest.ClosingIssuesReferences {
+		if reference.Number <= 0 {
+			continue
+		}
+		issue, err := a.issueLifecycle.FetchIssue(ctx, repo, reference.Number)
+		if err != nil {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to load linked issue #%d for PR #%d: %v\n", reference.Number, pullRequest.Number, err)
+			continue
+		}
+		linked = append(linked, issue)
+	}
+	return linked
+}
+
+func buildNativePRReviewPrompt(pullRequest githublifecycle.PullRequest, reviewItems []orchestration.ReviewFeedbackItem, linkedIssues []githublifecycle.Issue, lightweight bool) string {
+	issueContextLines := make([]string, 0, len(linkedIssues))
+	for _, issue := range linkedIssues {
+		issueContextLines = append(issueContextLines, strings.TrimSpace(fmt.Sprintf(
+			"- Issue #%d: %s\n  URL: %s\n  Body: %s",
+			issue.Number,
+			strings.TrimSpace(issue.Title),
+			strings.TrimSpace(issue.URL),
+			strings.TrimSpace(issue.Body),
+		)))
+	}
+	if len(issueContextLines) == 0 {
+		issueContextLines = append(issueContextLines, "- No linked issue context found.")
+	}
+	commentLines := make([]string, 0, len(reviewItems))
+	for index, item := range reviewItems {
+		author := fallbackString(strings.TrimSpace(item.Author), "unknown")
+		body := strings.TrimSpace(item.Body)
+		url := strings.TrimSpace(item.URL)
+		switch item.Type {
+		case "review_summary":
+			commentLines = append(commentLines, strings.TrimSpace(fmt.Sprintf(
+				"%d. Type: review_summary\n   Author: %s\n   State: %s\n   Feedback: %s\n   Link: %s",
+				index+1,
+				author,
+				strings.TrimSpace(item.State),
+				body,
+				url,
+			)))
+		case "conversation_comment":
+			commentLines = append(commentLines, strings.TrimSpace(fmt.Sprintf(
+				"%d. Type: conversation_comment\n   Author: %s\n   Feedback: %s\n   Link: %s",
+				index+1,
+				author,
+				body,
+				url,
+			)))
+		default:
+			location := strings.TrimSpace(item.Path)
+			if item.Line > 0 {
+				if location == "" {
+					location = fmt.Sprintf("%d", item.Line)
+				} else {
+					location = fmt.Sprintf("%s:%d", location, item.Line)
+				}
+			}
+			if location == "" {
+				location = "unknown-location"
+			}
+			commentLines = append(commentLines, strings.TrimSpace(fmt.Sprintf(
+				"%d. Type: review_comment\n   Author: %s\n   Location: %s\n   Feedback: %s\n   Link: %s",
+				index+1,
+				author,
+				location,
+				body,
+				url,
+			)))
+		}
+	}
+	if len(commentLines) == 0 {
+		commentLines = append(commentLines, "- No actionable review comments found.")
+	}
+	firstLine := "You are working on an existing GitHub pull request review cycle in the current git branch."
+	if lightweight {
+		firstLine = "You are working on a small follow-up for an existing GitHub pull request review cycle in the current git branch."
+	}
+	return strings.TrimSpace(fmt.Sprintf(
+		"%s\nImplement the fix requested in PR review comments in repository files.\nDo not run git commands; git actions are handled by orchestration script.\n\nIf the requested change is ambiguous, unsafe, or needs product/business judgment, do not guess and do not wait for interactive approval. Instead, stop and print %s followed by a JSON object like {\"question\":\"<focused question>\",\"reason\":\"<why clarification is required>\"}.\n\nPull Request: #%d - %s\nPR URL: %s\n\nPR description:\n%s\n\nLinked issue context:\n%s\n\nReview comments to address:\n%s",
+		firstLine,
+		orchestration.ClarificationRequestMarker,
+		pullRequest.Number,
+		strings.TrimSpace(pullRequest.Title),
+		strings.TrimSpace(pullRequest.URL),
+		strings.TrimSpace(pullRequest.Body),
+		strings.Join(issueContextLines, "\n"),
+		strings.Join(commentLines, "\n"),
+	))
+}
+
+func nativePRCommitTitle(pullRequest githublifecycle.PullRequest) string {
+	return fmt.Sprintf("Address review comments for PR #%d", pullRequest.Number)
+}
+
+func (a *App) safePostPRComment(ctx context.Context, repo string, prNumber int, body string) error {
+	return a.prLifecycle.CommentOnPullRequest(ctx, repo, prNumber, body)
+}
+
+func (a *App) safePostPRState(ctx context.Context, repo string, prNumber int, state orchestration.TrackedState) error {
+	body, err := orchestration.BuildOrchestrationStateComment(state)
+	if err != nil {
+		return err
+	}
+	return a.safePostPRComment(ctx, repo, prNumber, body)
+}


### PR DESCRIPTION
## Summary
- Adds a Go-native `run pr --from-review-comments` runtime for the supported explicit-repo path.
- Keeps Python compatibility fallback for PR modes that are not migrated yet (`--dry-run`, `--detach`, isolated worktree, post-summary/followup/conflict-recovery/sync-strategy/config-driven paths).
- Documents the updated PR runtime boundary and smoke checklist.

## Verification
- `go test ./...`
- `python3 -m unittest discover -s tests -q`

Part of #243.
Closes #278