### PR TITLE
Fix issue #282: Child of #243: Move reused issue branch sync preflight into Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ python3 -m unittest discover -s tests -p 'test_*.py'
 - If merge-based auto-resolution still cannot finish, the run stops before agent execution with a clear error and hints to resolve conflicts.
 - If sync updates branch history and agent produces no new file changes, the script first runs forced recovery verification and only then pushes sync-only branch updates so existing PR conflict status can be refreshed safely.
 - For rebase-based sync that rewrites branch history, push uses `--force-with-lease` automatically.
+- The Go-native `run issue` path now performs the normal reused-branch sync preflight itself; dedicated sync-only recovery mode (`--conflict-recovery-only`) still goes through the compatibility path.
 - Use `--sync-strategy merge` if you prefer merge-based sync instead of rebase.
 - Use `--no-sync-reused-branch` only when you intentionally want to skip auto-sync.
 - Recovery verification always runs full-repo checks (`workflow.commands` when configured, otherwise detected repo defaults). You can add `workflow.verification.focused_commands` to also run extra uncached checks in a fresh clone before the branch is considered safely recovered.

--- a/docs/current-behavior.md
+++ b/docs/current-behavior.md
@@ -17,7 +17,7 @@
 - Есть Go entrypoint `cmd/orchestrator`.
 - `init` создает scaffold для `project-config.json` и `local-config.json`.
 - `doctor` и `autodoctor` проверяют окружение, конфиг и могут делать runner smoke check.
-- `run issue` запускает Go-first one-shot issue orchestration для fresh-branch GitHub path.
+- `run issue` запускает Go-first one-shot issue orchestration для fresh-branch и reused-branch GitHub path.
 - `run batch` запускает явный список issue ID как batch entrypoint: в `--dry-run` режиме показывает per-issue запуск, а в `--detach` стартует отдельный worker на каждый issue.
 - `run pr` запускает review-comments flow для существующего PR.
 - `run daemon` запускает Go-owned polling/claim loop и затем dispatch'ит совместимый worker path для каждого выбранного таска.
@@ -25,7 +25,7 @@
 ### Issue flow
 
 - Поддерживаются одиночный запуск по `--issue` / `run issue --id` и batch/polling обработка списка issue.
-- Для нового GitHub issue без существующего branch/PR Go сам выбирает mode, готовит branch, запускает agent, коммитит, пушит и создает PR без вызова Python runner'а.
+- Для нового GitHub issue без существующего linked PR Go сам выбирает mode, готовит fresh/reused branch, при необходимости синхронизирует reused branch с base, запускает agent, коммитит, пушит и создает PR без вызова Python runner'а.
 - Скрипт создает или переиспользует deterministic issue branch и PR.
 - Для reused branch есть sync с base branch, стратегии `rebase` и `merge`, fallback с `rebase` на `merge` и conservative auto-resolution части merge conflicts.
 - Для image-only или image-backed issue attachments могут попадать в prompt.
@@ -83,7 +83,7 @@
 - `run pr` fallback paths, которые еще не перенесены в Go: `--dry-run`, `--isolate-worktree`, `--detach`, `--post-pr-summary`, follow-up branch mode и conflict-recovery/sync-only варианты;
 - `doctor`, `autodoctor`, `status` и другие еще не перенесенные CLI compatibility surfaces;
 - batch/daemon worker execution paths, которые все еще запускаются через script adapter;
-- issue-path blockers, еще не реализованные в Go: reused branch handling, linked PR reuse internals beyond adapter routing, dedicated conflict-recovery-only runtime.
+- issue-path blockers, еще не реализованные в Go: linked PR reuse internals beyond adapter routing и dedicated conflict-recovery-only runtime.
 
 ### Post-#204 safety invariants
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -926,6 +926,183 @@ func TestRunIssueUsesGoNativeHappyPath(t *testing.T) {
 	}
 }
 
+func TestRunIssueUsesGoNativeReusedBranchSyncPreflight(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 0},
+		{ExitCode: 0},
+		{},
+		{},
+		{},
+		{Stdout: "abc123\n"},
+		{},
+		{Stdout: "def456\n"},
+		{Stdout: ""},
+		{Stdout: "M internal/cli/command_run.go\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{},
+		{Stdout: ""},
+		{},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+		createPRURL:   "https://github.com/owner/repo/pull/101",
+	}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{Stats: agentexec.Stats{ElapsedSeconds: 12}}}
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--no-skip-if-branch-exists"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 1 {
+		t.Fatalf("agent call count = %d, want 1", agent.callCount)
+	}
+	if len(lifecycle.commentBodies[71]) != 2 {
+		t.Fatalf("comment bodies = %d, want 2", len(lifecycle.commentBodies[71]))
+	}
+	firstState, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][0])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody(first) error = %v", err)
+	}
+	if firstState.BranchLifecycle != orchestration.BranchLifecycleReused {
+		t.Fatalf("first state branch lifecycle = %q, want reused", firstState.BranchLifecycle)
+	}
+	if firstState.ReusedBranchSync == nil {
+		t.Fatal("first state reused_branch_sync = nil, want sync verdict")
+	}
+	if firstState.ReusedBranchSync.Status != orchestration.BranchSyncStatusSyncedCleanly || firstState.ReusedBranchSync.AppliedStrategy != "rebase" || !firstState.ReusedBranchSync.Changed {
+		t.Fatalf("first state sync verdict = %#v", firstState.ReusedBranchSync)
+	}
+	finalState, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][1])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody(final) error = %v", err)
+	}
+	if finalState.BranchLifecycle != orchestration.BranchLifecycleReused {
+		t.Fatalf("final state branch lifecycle = %q, want reused", finalState.BranchLifecycle)
+	}
+	if finalState.ReusedBranchSync == nil || finalState.ReusedBranchSync.AppliedStrategy != "rebase" {
+		t.Fatalf("final state sync verdict = %#v", finalState.ReusedBranchSync)
+	}
+	wantCommands := []string{
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("show-ref", "--verify", "--quiet", "refs/heads/issue-fix/71-fix-runner"),
+		gitCommand("ls-remote", "--exit-code", "--heads", "origin", "issue-fix/71-fix-runner"),
+		gitCommand("checkout", "main"),
+		gitCommand("checkout", "issue-fix/71-fix-runner"),
+		gitCommand("fetch", "origin", "main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("rebase", "origin/main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("ls-files", "--others", "--exclude-standard"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("add", "-u"),
+		gitCommand("ls-files", "--others", "--exclude-standard"),
+		gitCommand("commit", "-m", "Fix issue #71: Fix runner"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("push", "-u", "--force-with-lease", "origin", "issue-fix/71-fix-runner"),
+	}
+	if !reflect.DeepEqual(shell.cmds, wantCommands) {
+		t.Fatalf("shell commands = %#v, want %#v", shell.cmds, wantCommands)
+	}
+}
+
+func TestRunIssueBlocksWhenReusedBranchSyncCannotBeRecovered(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 0},
+		{ExitCode: 0},
+		{},
+		{},
+		{},
+		{Stdout: "abc123\n"},
+		{ExitCode: 1, Stderr: "merge conflict\n"},
+		{Stdout: ""},
+		{},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+	}
+	agent := &fakeIssueAgentRunner{}
+	var errOut strings.Builder
+	app := NewApp(&strings.Builder{}, &errOut)
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--no-skip-if-branch-exists", "--sync-strategy", "merge"})
+	if code != 1 {
+		t.Fatalf("Run() code = %d, want 1", code)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 0 {
+		t.Fatalf("agent call count = %d, want 0", agent.callCount)
+	}
+	if len(lifecycle.commentBodies[71]) != 1 {
+		t.Fatalf("comment bodies = %d, want 1", len(lifecycle.commentBodies[71]))
+	}
+	blockedState, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][0])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody(blocked) error = %v", err)
+	}
+	if blockedState.Status != orchestration.StatusBlocked || blockedState.Stage != "sync_branch" {
+		t.Fatalf("blocked state = %#v", blockedState)
+	}
+	if blockedState.BranchLifecycle != orchestration.BranchLifecycleReused {
+		t.Fatalf("blocked branch lifecycle = %q, want reused", blockedState.BranchLifecycle)
+	}
+	if !strings.Contains(blockedState.Error, "resolve conflicts manually") {
+		t.Fatalf("blocked error = %q, want manual resolution hint", blockedState.Error)
+	}
+	wantCommands := []string{
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("show-ref", "--verify", "--quiet", "refs/heads/issue-fix/71-fix-runner"),
+		gitCommand("ls-remote", "--exit-code", "--heads", "origin", "issue-fix/71-fix-runner"),
+		gitCommand("checkout", "main"),
+		gitCommand("checkout", "issue-fix/71-fix-runner"),
+		gitCommand("fetch", "origin", "main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("merge", "--no-edit", "-X", "theirs", "origin/main"),
+		gitCommand("diff", "--name-only", "--diff-filter=U"),
+		gitCommand("merge", "--abort"),
+	}
+	if !reflect.DeepEqual(shell.cmds, wantCommands) {
+		t.Fatalf("shell commands = %#v, want %#v", shell.cmds, wantCommands)
+	}
+	if !strings.Contains(errOut.String(), "failed to prepare issue branch") {
+		t.Fatalf("stderr = %q, want explicit sync preflight failure", errOut.String())
+	}
+}
+
 func TestRunIssueRoutesLinkedPRToPRCompatibilityAdapter(t *testing.T) {
 	runner := &recordingRunner{}
 	lifecycle := &fakeDaemonLifecycle{

--- a/internal/cli/issue_native.go
+++ b/internal/cli/issue_native.go
@@ -240,32 +240,13 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 			_, _ = fmt.Fprintf(a.out, "Skipping issue #%d: branch %q already exists\n", issue.Number, issueBranch)
 			return 0
 		}
-		_, _ = fmt.Fprintln(a.err, "orchestrator: falling back to python issue runner: branch reuse is not supported by the Go-native issue path yet")
-		return a.runPython(ctx, buildIssuePythonArgs(
-			a.runtime.RunnerScript(),
-			opts.common,
-			issue.Number,
-			opts.base,
-			opts.includeEmpty,
-			false,
-			opts.failOnExisting,
-			opts.forceIssueFlow,
-			opts.skipIfPRExists,
-			opts.noSkipIfPRExists,
-			opts.skipIfBranchExists,
-			opts.noSkipIfBranchExists,
-			opts.forceReprocess,
-			opts.conflictRecoveryOnly,
-			opts.syncReusedBranch,
-			opts.noSyncReusedBranch,
-			opts.syncStrategy,
-			nilFlagState{},
-		))
 	}
 
 	runnerName := fallbackString(strings.TrimSpace(*opts.common.runner), nativeIssueDefaultRunner)
 	agentName := fallbackString(strings.TrimSpace(*opts.common.agent), nativeIssueDefaultAgent)
 	modelName := fallbackString(strings.TrimSpace(*opts.common.model), nativeIssueDefaultModel)
+	branchLifecycle := orchestration.BranchLifecycleCreated
+	var reusedBranchSync *orchestration.ReusedBranchSyncVerdict
 	postState := func(state orchestration.TrackedState) {
 		if err := a.safePostIssueState(ctx, repo, issue.Number, state); err != nil {
 			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post state for issue #%d: %v\n", issue.Number, err)
@@ -273,40 +254,48 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 	}
 	failedState := func(stage, nextAction, message string) orchestration.TrackedState {
 		return orchestration.TrackedState{
-			Status:     orchestration.StatusFailed,
-			TaskType:   "issue",
-			Issue:      intPtr(issue.Number),
-			Branch:     issueBranch,
-			BaseBranch: baseBranch,
-			Runner:     runnerName,
-			Agent:      agentName,
-			Model:      modelName,
-			Attempt:    1,
-			Stage:      stage,
-			NextAction: nextAction,
-			Error:      message,
-			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+			Status:           orchestration.StatusFailed,
+			TaskType:         "issue",
+			Issue:            intPtr(issue.Number),
+			Branch:           issueBranch,
+			BranchLifecycle:  branchLifecycle,
+			BaseBranch:       baseBranch,
+			Runner:           runnerName,
+			Agent:            agentName,
+			Model:            modelName,
+			Attempt:          1,
+			Stage:            stage,
+			NextAction:       nextAction,
+			Error:            message,
+			Timestamp:        time.Now().UTC().Format(time.RFC3339),
+			ReusedBranchSync: reusedBranchSync,
 		}
 	}
-	postState(orchestration.TrackedState{
-		Status:     orchestration.StatusInProgress,
-		TaskType:   "issue",
-		Issue:      intPtr(issue.Number),
-		Branch:     issueBranch,
-		BaseBranch: baseBranch,
-		Runner:     runnerName,
-		Agent:      agentName,
-		Model:      modelName,
-		Attempt:    1,
-		Stage:      "agent_run",
-		NextAction: "wait_for_agent_result",
-		Timestamp:  time.Now().UTC().Format(time.RFC3339),
-	})
-	if err := a.checkoutFreshIssueBranch(ctx, repoRoot, baseBranch, issueBranch); err != nil {
-		postState(failedState("prepare_branch", "inspect_branch_setup", err.Error()))
+	pushAfterAgentWithLease := false
+	branchLifecycle, reusedBranchSync, pushAfterAgentWithLease, err = a.prepareIssueBranchPreflight(ctx, repoRoot, baseBranch, issueBranch, localBranchExists, remoteBranchExists, opts.syncReusedBranch, opts.syncStrategy)
+	if err != nil {
+		state := failedState("sync_branch", "resolve_branch_sync_conflict", err.Error())
+		state.Status = orchestration.StatusBlocked
+		postState(state)
 		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to prepare issue branch %q: %v\n", issueBranch, err)
 		return 1
 	}
+	postState(orchestration.TrackedState{
+		Status:           orchestration.StatusInProgress,
+		TaskType:         "issue",
+		Issue:            intPtr(issue.Number),
+		Branch:           issueBranch,
+		BranchLifecycle:  branchLifecycle,
+		BaseBranch:       baseBranch,
+		Runner:           runnerName,
+		Agent:            agentName,
+		Model:            modelName,
+		Attempt:          1,
+		Stage:            "agent_run",
+		NextAction:       "wait_for_agent_result",
+		Timestamp:        time.Now().UTC().Format(time.RFC3339),
+		ReusedBranchSync: reusedBranchSync,
+	})
 	preRunUntracked, err := a.gitUntrackedFiles(ctx, repoRoot)
 	if err != nil {
 		postState(failedState("agent_run", "inspect_git_status", err.Error()))
@@ -343,20 +332,22 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 				_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post clarification request for issue #%d: %v\n", issue.Number, err)
 			}
 			postState(orchestration.TrackedState{
-				Status:     orchestration.StatusWaitingForAuthor,
-				TaskType:   "issue",
-				Issue:      intPtr(issue.Number),
-				Branch:     issueBranch,
-				BaseBranch: baseBranch,
-				Runner:     runnerName,
-				Agent:      agentName,
-				Model:      modelName,
-				Attempt:    1,
-				Stage:      "agent_run",
-				NextAction: "await_author_reply",
-				Error:      reason,
-				Timestamp:  time.Now().UTC().Format(time.RFC3339),
-				Stats:      statsMap(result.Stats),
+				Status:           orchestration.StatusWaitingForAuthor,
+				TaskType:         "issue",
+				Issue:            intPtr(issue.Number),
+				Branch:           issueBranch,
+				BranchLifecycle:  branchLifecycle,
+				BaseBranch:       baseBranch,
+				Runner:           runnerName,
+				Agent:            agentName,
+				Model:            modelName,
+				Attempt:          1,
+				Stage:            "agent_run",
+				NextAction:       "await_author_reply",
+				Error:            reason,
+				Timestamp:        time.Now().UTC().Format(time.RFC3339),
+				ReusedBranchSync: reusedBranchSync,
+				Stats:            statsMap(result.Stats),
 			})
 			_, _ = fmt.Fprintf(a.out, "Paused issue #%d for clarification: %s\n", issue.Number, question)
 			return 0
@@ -370,20 +361,22 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 	}
 	if !hasChanges {
 		postState(orchestration.TrackedState{
-			Status:     orchestration.StatusWaitingForAuthor,
-			TaskType:   "issue",
-			Issue:      intPtr(issue.Number),
-			Branch:     issueBranch,
-			BaseBranch: baseBranch,
-			Runner:     runnerName,
-			Agent:      agentName,
-			Model:      modelName,
-			Attempt:    1,
-			Stage:      "agent_run",
-			NextAction: "inspect_noop_result",
-			Error:      "Agent finished without changing the worktree",
-			Timestamp:  time.Now().UTC().Format(time.RFC3339),
-			Stats:      statsMap(result.Stats),
+			Status:           orchestration.StatusWaitingForAuthor,
+			TaskType:         "issue",
+			Issue:            intPtr(issue.Number),
+			Branch:           issueBranch,
+			BranchLifecycle:  branchLifecycle,
+			BaseBranch:       baseBranch,
+			Runner:           runnerName,
+			Agent:            agentName,
+			Model:            modelName,
+			Attempt:          1,
+			Stage:            "agent_run",
+			NextAction:       "inspect_noop_result",
+			Error:            "Agent finished without changing the worktree",
+			Timestamp:        time.Now().UTC().Format(time.RFC3339),
+			ReusedBranchSync: reusedBranchSync,
+			Stats:            statsMap(result.Stats),
 		})
 		_, _ = fmt.Fprintf(a.out, "No changes detected for issue #%d; skipping commit and PR\n", issue.Number)
 		return 0
@@ -404,7 +397,7 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to commit issue changes: %v\n", err)
 		return 1
 	}
-	if err := a.gitPushBranch(ctx, repoRoot, issueBranch); err != nil {
+	if err := a.gitPushBranch(ctx, repoRoot, issueBranch, pushAfterAgentWithLease); err != nil {
 		postState(failedState("commit_push", "inspect_push_failure", err.Error()))
 		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push issue branch %q: %v\n", issueBranch, err)
 		return 1
@@ -426,20 +419,22 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 	}
 	prNumber := parsePullRequestNumber(prURL)
 	postState(orchestration.TrackedState{
-		Status:     orchestration.StatusReadyForReview,
-		TaskType:   "issue",
-		Issue:      intPtr(issue.Number),
-		PR:         prNumber,
-		Branch:     issueBranch,
-		BaseBranch: baseBranch,
-		Runner:     runnerName,
-		Agent:      agentName,
-		Model:      modelName,
-		Attempt:    1,
-		Stage:      "pr_ready",
-		NextAction: "wait_for_review",
-		Timestamp:  time.Now().UTC().Format(time.RFC3339),
-		Stats:      statsMap(result.Stats),
+		Status:           orchestration.StatusReadyForReview,
+		TaskType:         "issue",
+		Issue:            intPtr(issue.Number),
+		PR:               prNumber,
+		Branch:           issueBranch,
+		BranchLifecycle:  branchLifecycle,
+		BaseBranch:       baseBranch,
+		Runner:           runnerName,
+		Agent:            agentName,
+		Model:            modelName,
+		Attempt:          1,
+		Stage:            "pr_ready",
+		NextAction:       "wait_for_review",
+		Timestamp:        time.Now().UTC().Format(time.RFC3339),
+		ReusedBranchSync: reusedBranchSync,
+		Stats:            statsMap(result.Stats),
 	})
 	if prURL != "" {
 		_, _ = fmt.Fprintf(a.out, "Prepared issue #%d for review: %s\n", issue.Number, prURL)
@@ -598,6 +593,154 @@ func (a *App) checkoutFreshIssueBranch(ctx context.Context, repoRoot, baseBranch
 	return nil
 }
 
+func (a *App) prepareIssueBranchPreflight(ctx context.Context, repoRoot, baseBranch, branchName string, localExists, remoteExists, syncReusedBranch bool, strategy string) (string, *orchestration.ReusedBranchSyncVerdict, bool, error) {
+	if !localExists && !remoteExists {
+		if err := a.checkoutFreshIssueBranch(ctx, repoRoot, baseBranch, branchName); err != nil {
+			return orchestration.BranchLifecycleCreated, nil, false, err
+		}
+		return orchestration.BranchLifecycleCreated, nil, false, nil
+	}
+
+	if _, err := a.runGit(ctx, repoRoot, "checkout", baseBranch); err != nil {
+		return orchestration.BranchLifecycleReused, nil, false, err
+	}
+	if localExists {
+		if _, err := a.runGit(ctx, repoRoot, "checkout", branchName); err != nil {
+			return orchestration.BranchLifecycleReused, nil, false, err
+		}
+	} else {
+		if _, err := a.runGit(ctx, repoRoot, "checkout", "-b", branchName, "--track", "origin/"+branchName); err != nil {
+			return orchestration.BranchLifecycleReused, nil, false, err
+		}
+	}
+
+	if !syncReusedBranch {
+		return orchestration.BranchLifecycleReused, nil, false, nil
+	}
+
+	verdict, err := a.syncReusedIssueBranchWithBase(ctx, repoRoot, baseBranch, branchName, strategy)
+	if err != nil {
+		return orchestration.BranchLifecycleReused, nil, false, err
+	}
+	useForceWithLease := verdict.Changed && strings.TrimSpace(verdict.AppliedStrategy) == "rebase"
+	return orchestration.BranchLifecycleReused, &verdict, useForceWithLease, nil
+}
+
+func normalizeSyncStrategy(strategy string) (string, error) {
+	normalized := strings.TrimSpace(strategy)
+	if normalized == "" {
+		return "rebase", nil
+	}
+	switch normalized {
+	case "rebase", "merge":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported sync strategy %q (want rebase or merge)", strategy)
+	}
+}
+
+func (a *App) syncReusedIssueBranchWithBase(ctx context.Context, repoRoot, baseBranch, branchName, strategy string) (orchestration.ReusedBranchSyncVerdict, error) {
+	normalizedStrategy, err := normalizeSyncStrategy(strategy)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	remoteBaseRef := "origin/" + strings.TrimSpace(baseBranch)
+	if _, err := a.runGit(ctx, repoRoot, "fetch", "origin", baseBranch); err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	if normalizedStrategy == "merge" {
+		return a.mergeSyncWithAutoResolution(ctx, repoRoot, remoteBaseRef, branchName, normalizedStrategy)
+	}
+
+	beforeSyncSHA, err := a.gitCurrentHeadSHA(ctx, repoRoot)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	if _, err := a.runGit(ctx, repoRoot, "rebase", remoteBaseRef); err != nil {
+		_, _ = a.gitCommandSucceeds(ctx, repoRoot, "rebase", "--abort")
+		return a.mergeSyncWithAutoResolution(ctx, repoRoot, remoteBaseRef, branchName, normalizedStrategy)
+	}
+	afterSyncSHA, err := a.gitCurrentHeadSHA(ctx, repoRoot)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	changed := beforeSyncSHA != afterSyncSHA
+	return orchestration.ReusedBranchSyncVerdict{
+		BranchName:        branchName,
+		RemoteBaseRef:     remoteBaseRef,
+		RequestedStrategy: normalizedStrategy,
+		AppliedStrategy:   "rebase",
+		Status:            branchSyncStatus(changed, false),
+		Changed:           changed,
+		AutoResolved:      false,
+	}, nil
+}
+
+func (a *App) mergeSyncWithAutoResolution(ctx context.Context, repoRoot, remoteBaseRef, branchName, requestedStrategy string) (orchestration.ReusedBranchSyncVerdict, error) {
+	beforeSyncSHA, err := a.gitCurrentHeadSHA(ctx, repoRoot)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	autoResolved := false
+	if _, err := a.runGit(ctx, repoRoot, "merge", "--no-edit", "-X", "theirs", remoteBaseRef); err != nil {
+		autoResolved = true
+		if err := a.autoResolveMergeConflictsWithBase(ctx, repoRoot, remoteBaseRef); err != nil {
+			_, _ = a.gitCommandSucceeds(ctx, repoRoot, "merge", "--abort")
+			return orchestration.ReusedBranchSyncVerdict{}, fmt.Errorf(
+				"failed to auto-resolve merge conflicts while syncing reused branch %q with %q: resolve conflicts manually or rerun with --no-sync-reused-branch",
+				branchName,
+				remoteBaseRef,
+			)
+		}
+	}
+	afterSyncSHA, err := a.gitCurrentHeadSHA(ctx, repoRoot)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	changed := beforeSyncSHA != afterSyncSHA
+	return orchestration.ReusedBranchSyncVerdict{
+		BranchName:        branchName,
+		RemoteBaseRef:     remoteBaseRef,
+		RequestedStrategy: requestedStrategy,
+		AppliedStrategy:   "merge",
+		Status:            branchSyncStatus(changed, autoResolved),
+		Changed:           changed,
+		AutoResolved:      autoResolved && changed,
+	}, nil
+}
+
+func branchSyncStatus(changed, autoResolved bool) string {
+	if !changed {
+		return orchestration.BranchSyncStatusAlreadyCurrent
+	}
+	if autoResolved {
+		return orchestration.BranchSyncStatusAutoResolved
+	}
+	return orchestration.BranchSyncStatusSyncedCleanly
+}
+
+func (a *App) autoResolveMergeConflictsWithBase(ctx context.Context, repoRoot, remoteBaseRef string) error {
+	conflictedPaths, err := a.gitConflictedPaths(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	if len(conflictedPaths) == 0 {
+		return fmt.Errorf("merge with %q reported conflicts, but no conflicted files were detected", remoteBaseRef)
+	}
+	for _, path := range conflictedPaths {
+		if _, err := a.runGit(ctx, repoRoot, "checkout", "--theirs", "--", path); err != nil {
+			return err
+		}
+	}
+	if _, err := a.runGit(ctx, repoRoot, "add", "-A"); err != nil {
+		return err
+	}
+	if _, err := a.runGit(ctx, repoRoot, "commit", "--no-edit"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *App) gitStageIssueChanges(ctx context.Context, repoRoot string, baseline []string) error {
 	if _, err := a.runGit(ctx, repoRoot, "add", "-u"); err != nil {
 		return err
@@ -630,11 +773,16 @@ func (a *App) gitCommit(ctx context.Context, repoRoot, message string) error {
 	return err
 }
 
-func (a *App) gitPushBranch(ctx context.Context, repoRoot, branchName string) error {
+func (a *App) gitPushBranch(ctx context.Context, repoRoot, branchName string, forceWithLease bool) error {
 	if err := a.assertNativeGitContext(ctx, repoRoot, branchName, "push branch"); err != nil {
 		return err
 	}
-	_, err := a.runGit(ctx, repoRoot, "push", "-u", "origin", branchName)
+	args := []string{"push", "-u"}
+	if forceWithLease {
+		args = append(args, "--force-with-lease")
+	}
+	args = append(args, "origin", branchName)
+	_, err := a.runGit(ctx, repoRoot, args...)
 	return err
 }
 
@@ -666,6 +814,14 @@ func (a *App) gitRepoRoot(ctx context.Context, cwd string) (string, error) {
 
 func (a *App) gitCurrentBranch(ctx context.Context, cwd string) (string, error) {
 	stdout, err := a.runGit(ctx, cwd, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
+func (a *App) gitCurrentHeadSHA(ctx context.Context, cwd string) (string, error) {
+	stdout, err := a.runGit(ctx, cwd, "rev-parse", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -726,6 +882,34 @@ func (a *App) gitUntrackedFiles(ctx context.Context, cwd string) ([]string, erro
 	}
 	sort.Strings(files)
 	return files, nil
+}
+
+func (a *App) gitConflictedPaths(ctx context.Context, cwd string) ([]string, error) {
+	stdout, err := a.runGit(ctx, cwd, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(stdout) == "" {
+		return nil, nil
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	paths := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func (a *App) gitCommandSucceeds(ctx context.Context, cwd string, args ...string) (bool, error) {
+	result, err := a.runShell(ctx, cwd, gitCommand(args...))
+	if err != nil {
+		return false, err
+	}
+	return result.ExitCode == 0, nil
 }
 
 func (a *App) runGit(ctx context.Context, cwd string, args ...string) (string, error) {

--- a/internal/cli/pr_native.go
+++ b/internal/cli/pr_native.go
@@ -314,7 +314,7 @@ func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions
 			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to commit PR changes: %v\n", err)
 			return 1
 		}
-		if err := a.gitPushBranch(ctx, repoRoot, activeBranch); err != nil {
+		if err := a.gitPushBranch(ctx, repoRoot, activeBranch, false); err != nil {
 			postState(failedState(attempt, "commit_push", "inspect_push_failure", err.Error()))
 			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push PR branch %q: %v\n", activeBranch, err)
 			return 1

--- a/internal/core/orchestration/state_models.go
+++ b/internal/core/orchestration/state_models.go
@@ -35,6 +35,7 @@ type TrackedState struct {
 	Issue                  *int                      `json:"issue,omitempty"`
 	PR                     *int                      `json:"pr,omitempty"`
 	Branch                 string                    `json:"branch,omitempty"`
+	BranchLifecycle        string                    `json:"branch_lifecycle,omitempty"`
 	BaseBranch             string                    `json:"base_branch,omitempty"`
 	Runner                 string                    `json:"runner,omitempty"`
 	Agent                  string                    `json:"agent,omitempty"`
@@ -52,6 +53,7 @@ type TrackedState struct {
 	CIDiagnostics          *CIDiagnostics            `json:"ci_diagnostics,omitempty"`
 	ResidualUntrackedFiles []string                  `json:"residual_untracked_files,omitempty"`
 	ResidualUntrackedCount int                       `json:"residual_untracked_count,omitempty"`
+	ReusedBranchSync       *ReusedBranchSyncVerdict  `json:"reused_branch_sync,omitempty"`
 	Stats                  map[string]any            `json:"stats,omitempty"`
 	Decomposition          map[string]any            `json:"decomposition,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Moves reused issue branch sync preflight into the Go-native issue path.
- Adds branch lifecycle and reused-branch sync details to orchestration state comments.
- Keeps conflict/manual-intervention failures explicit without delegating the migrated case to Python.

## Verification
- `go test ./...`
- `python3 -m unittest discover -s tests -q`

Part of #243.
Closes #282