### PR TITLE
Fix issue #283: Child of #243: Remove Python adapter from daemon/batch worker dispatch where Go paths exist

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/podlodka-ai-club/steam-hammer/internal/core/agentexec"
 	"github.com/podlodka-ai-club/steam-hammer/internal/core/githublifecycle"
@@ -21,6 +22,7 @@ type App struct {
 	prLifecycle    prReviewLifecycle
 	agentRunner    issueAgentRunner
 	runtime        runtimeProvider
+	executablePath func() (string, error)
 }
 
 func NewApp(out, err io.Writer) *App {
@@ -37,6 +39,7 @@ func NewApp(out, err io.Writer) *App {
 		prLifecycle:    adapter,
 		agentRunner:    nativeIssueAgentRunner{},
 		runtime:        defaultRuntimeProvider(),
+		executablePath: os.Executable,
 	}
 }
 
@@ -88,6 +91,16 @@ func (a *App) SetRuntimeProvider(provider runtimeProvider) {
 		return
 	}
 	a.runtime = provider
+}
+
+func (a *App) SetExecutablePath(path string) {
+	if path == "" {
+		a.executablePath = os.Executable
+		return
+	}
+	a.executablePath = func() (string, error) {
+		return path, nil
+	}
 }
 
 func (a *App) Run(args []string) int {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -926,6 +926,86 @@ func TestRunIssueUsesGoNativeHappyPath(t *testing.T) {
 	}
 }
 
+func TestRunIssueNativePersistsAutonomousSessionCheckpoint(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 1},
+		{ExitCode: 2},
+		{},
+		{},
+		{Stdout: ""},
+		{Stdout: "M internal/cli/command_run.go\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{},
+		{Stdout: "new.txt\n"},
+		{},
+		{},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+		createPRURL:   "https://github.com/owner/repo/pull/101",
+	}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{Stats: agentexec.Stats{ElapsedSeconds: 12}}}
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--autonomous-session-file", sessionPath})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	state, err := orchestration.LoadState(sessionPath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.Checkpoint == nil {
+		t.Fatal("checkpoint = nil")
+	}
+	if got := state.Checkpoint.Phase; got != "completed" {
+		t.Fatalf("checkpoint phase = %q, want completed", got)
+	}
+	if got := state.Checkpoint.Current; got != "Idle between autonomous runs" {
+		t.Fatalf("checkpoint current = %q", got)
+	}
+	if got := state.Checkpoint.Counts.Processed; got != 1 {
+		t.Fatalf("processed count = %d, want 1", got)
+	}
+	if got := state.Checkpoint.Counts.Failures; got != 0 {
+		t.Fatalf("failure count = %d, want 0", got)
+	}
+	if !reflect.DeepEqual(state.Checkpoint.Done, []string{"issue #71 (ready-for-review)"}) {
+		t.Fatalf("done = %#v", state.Checkpoint.Done)
+	}
+	if !reflect.DeepEqual(state.Checkpoint.Next, []string{"wait for review"}) {
+		t.Fatalf("next = %#v", state.Checkpoint.Next)
+	}
+	if !reflect.DeepEqual(state.Checkpoint.IssuePRActions, []string{"prepared PR #101 for review"}) {
+		t.Fatalf("issue/pr actions = %#v", state.Checkpoint.IssuePRActions)
+	}
+	raw := state.ProcessedIssues["71"]
+	if len(raw) == 0 {
+		t.Fatal("processed issue entry for 71 is missing")
+	}
+	var tracked orchestration.TrackedState
+	if err := json.Unmarshal(raw, &tracked); err != nil {
+		t.Fatalf("json.Unmarshal(processed issue) error = %v", err)
+	}
+	if tracked.Status != orchestration.StatusReadyForReview {
+		t.Fatalf("processed issue status = %q, want ready-for-review", tracked.Status)
+	}
+}
+
 func TestRunIssueUsesGoNativeReusedBranchSyncPreflight(t *testing.T) {
 	runner := &recordingRunner{}
 	shell := &fakeShellExecutor{results: []shellExecutionResult{
@@ -1781,6 +1861,110 @@ func TestRunPRUsesNativeRuntimeLoopWhenRepoExplicit(t *testing.T) {
 	}
 	if !strings.Contains(joinedShell, "git 'push' '-u' 'origin' 'feature/pr-72'") {
 		t.Fatalf("shell commands missing PR push: %s", joinedShell)
+	}
+}
+
+func TestRunPRNativePersistsAutonomousSessionCheckpoint(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: ""},
+		{Stdout: " M internal/cli/pr_native.go\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: ""},
+		{Stdout: "[feature/pr-72 abc123] Address review comments for PR #72\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: "pushed\n"},
+	}}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{ExitCode: 0, Stats: agentexec.Stats{ElapsedSeconds: 5}}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue: githublifecycle.Issue{Number: 243, Title: "Parent issue", Body: "Parent issue body", URL: "https://github.com/owner/repo/issues/243", Tracker: githublifecycle.TrackerGitHub},
+		pullRequests: []githublifecycle.PullRequest{
+			{
+				Number:                  72,
+				Title:                   "Move PR review runtime loop into Go",
+				Body:                    "PR description",
+				URL:                     "https://github.com/owner/repo/pull/72",
+				HeadRefName:             "feature/pr-72",
+				BaseRefName:             "main",
+				Author:                  &githublifecycle.Actor{Login: "author"},
+				ClosingIssuesReferences: []githublifecycle.IssueReference{{Number: 243}},
+			},
+			{
+				Number:                  72,
+				Title:                   "Move PR review runtime loop into Go",
+				Body:                    "PR description",
+				URL:                     "https://github.com/owner/repo/pull/72",
+				HeadRefName:             "feature/pr-72",
+				BaseRefName:             "main",
+				Author:                  &githublifecycle.Actor{Login: "author"},
+				ClosingIssuesReferences: []githublifecycle.IssueReference{{Number: 243}},
+			},
+		},
+		reviewThreadSeq: [][]githublifecycle.PullRequestReviewThread{
+			{{
+				Comments: []githublifecycle.PullRequestReviewComment{{
+					Body:   "Please add a regression test",
+					Path:   "internal/cli/pr_native.go",
+					Line:   12,
+					Author: &githublifecycle.Actor{Login: "reviewer"},
+				}},
+			}},
+			{},
+		},
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueAgentRunner(agent)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetPRLifecycle(lifecycle)
+
+	code := app.Run([]string{"run", "pr", "--id", "72", "--repo", "owner/repo", "--autonomous-session-file", sessionPath})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	state, err := orchestration.LoadState(sessionPath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.Checkpoint == nil {
+		t.Fatal("checkpoint = nil")
+	}
+	if got := state.Checkpoint.Phase; got != "completed" {
+		t.Fatalf("checkpoint phase = %q, want completed", got)
+	}
+	if got := state.Checkpoint.Counts.Processed; got != 1 {
+		t.Fatalf("processed count = %d, want 1", got)
+	}
+	if got := state.Checkpoint.Counts.Failures; got != 0 {
+		t.Fatalf("failure count = %d, want 0", got)
+	}
+	if !reflect.DeepEqual(state.Checkpoint.Done, []string{"PR #72 (waiting-for-ci)"}) {
+		t.Fatalf("done = %#v", state.Checkpoint.Done)
+	}
+	if !reflect.DeepEqual(state.Checkpoint.Next, []string{"wait for ci"}) {
+		t.Fatalf("next = %#v", state.Checkpoint.Next)
+	}
+	if !reflect.DeepEqual(state.Checkpoint.IssuePRActions, []string{"pushed PR updates and waiting for CI"}) {
+		t.Fatalf("issue/pr actions = %#v", state.Checkpoint.IssuePRActions)
+	}
+	raw := state.ProcessedIssues["72"]
+	if len(raw) == 0 {
+		t.Fatal("processed PR entry for 72 is missing")
+	}
+	var tracked orchestration.TrackedState
+	if err := json.Unmarshal(raw, &tracked); err != nil {
+		t.Fatalf("json.Unmarshal(processed PR) error = %v", err)
+	}
+	if tracked.Status != orchestration.StatusWaitingForCI {
+		t.Fatalf("processed PR status = %q, want waiting-for-ci", tracked.Status)
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1181,10 +1181,13 @@ func TestRunBatchDetachStartsOneWorkerPerIssue(t *testing.T) {
 	starter := &recordingDetachedStarter{pid: 31337}
 	cloner := &recordingBatchClonePreparer{}
 	targetDir := t.TempDir()
+	execPath := filepath.Join(targetDir, "orchestrator")
 	var out strings.Builder
 	app := NewApp(&out, &strings.Builder{})
 	app.SetDetachedStarter(starter)
 	app.SetBatchClonePreparer(cloner)
+	app.SetExecutablePath(execPath)
+	app.SetIssueLifecycle(&fakeDaemonLifecycle{commentsByIssue: map[int][]githublifecycle.IssueComment{}})
 
 	code := app.Run([]string{"run", "batch", "--ids", "71,72", "--repo", "owner/repo", "--dir", targetDir, "--detach"})
 	if code != 0 {
@@ -1198,6 +1201,14 @@ func TestRunBatchDetachStartsOneWorkerPerIssue(t *testing.T) {
 	}
 	if len(starter.reqs) != 2 {
 		t.Fatalf("starter requests = %d, want 2", len(starter.reqs))
+	}
+	for _, req := range starter.reqs {
+		if req.Name != execPath {
+			t.Fatalf("worker command = %q, want %q", req.Name, execPath)
+		}
+		if len(req.Args) < 4 || !reflect.DeepEqual(req.Args[:4], []string{"run", "issue", "--id", flagValue(req.Args, "--id")}) {
+			t.Fatalf("worker args = %#v, want run issue entrypoint", req.Args)
+		}
 	}
 	if starter.reqs[0].Dir == starter.reqs[1].Dir {
 		t.Fatalf("worker dirs should differ, got %q", starter.reqs[0].Dir)
@@ -1231,6 +1242,62 @@ func TestRunBatchDetachStartsOneWorkerPerIssue(t *testing.T) {
 		if !strings.Contains(printed, want) {
 			t.Fatalf("stdout = %q, want %q", printed, want)
 		}
+	}
+}
+
+func TestRunBatchDetachRoutesLinkedPRToNativePRCommand(t *testing.T) {
+	starter := &recordingDetachedStarter{pid: 31337}
+	cloner := &recordingBatchClonePreparer{}
+	targetDir := t.TempDir()
+	execPath := filepath.Join(targetDir, "orchestrator")
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetDetachedStarter(starter)
+	app.SetBatchClonePreparer(cloner)
+	app.SetExecutablePath(execPath)
+	app.SetIssueLifecycle(&fakeDaemonLifecycle{
+		issue:           githublifecycle.Issue{Number: 71, Title: "Fix runtime", Body: "Body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		linkedPR:        &githublifecycle.PullRequest{Number: 101, Title: "Existing fix", HeadRefName: "feature/pr-101", BaseRefName: "main"},
+		commentsByIssue: map[int][]githublifecycle.IssueComment{},
+	})
+
+	code := app.Run([]string{"run", "batch", "--ids", "71", "--repo", "owner/repo", "--dir", targetDir, "--detach"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if starter.calls != 1 {
+		t.Fatalf("starter calls = %d, want 1", starter.calls)
+	}
+	if starter.req.Name != execPath {
+		t.Fatalf("worker command = %q, want %q", starter.req.Name, execPath)
+	}
+	if !reflect.DeepEqual(starter.req.Args[:4], []string{"run", "pr", "--id", "101"}) {
+		t.Fatalf("worker args = %#v, want native pr entrypoint", starter.req.Args)
+	}
+}
+
+func TestRunBatchDetachFallsBackToPythonWhenNativeIssueUnsupported(t *testing.T) {
+	starter := &recordingDetachedStarter{pid: 31337}
+	cloner := &recordingBatchClonePreparer{}
+	targetDir := t.TempDir()
+	var errOut strings.Builder
+	app := NewApp(&strings.Builder{}, &errOut)
+	app.SetDetachedStarter(starter)
+	app.SetBatchClonePreparer(cloner)
+	app.SetExecutablePath(filepath.Join(targetDir, "orchestrator"))
+	app.SetIssueLifecycle(&fakeDaemonLifecycle{commentsByIssue: map[int][]githublifecycle.IssueComment{}})
+
+	code := app.Run([]string{"run", "batch", "--ids", "71", "--repo", "owner/repo", "--dir", targetDir, "--detach", "--project-config", "project.json"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if starter.req.Name != "python3" {
+		t.Fatalf("worker command = %q, want python3", starter.req.Name)
+	}
+	if len(starter.req.Args) < 3 || !reflect.DeepEqual(starter.req.Args[:3], []string{runnerScript, "--issue", "71"}) {
+		t.Fatalf("worker args = %#v, want python issue adapter", starter.req.Args)
+	}
+	if !strings.Contains(errOut.String(), "--project-config is not supported by the Go-native issue path yet") {
+		t.Fatalf("stderr = %q, want explicit native fallback reason", errOut.String())
 	}
 }
 
@@ -1415,10 +1482,12 @@ func TestRunDaemonDetachStartsOneWorkerPerParallelTask(t *testing.T) {
 	starter := &recordingDetachedStarter{pid: 31337}
 	cloner := &recordingBatchClonePreparer{}
 	targetDir := t.TempDir()
+	execPath := filepath.Join(targetDir, "orchestrator")
 	var out strings.Builder
 	app := NewApp(&out, &strings.Builder{})
 	app.SetDetachedStarter(starter)
 	app.SetBatchClonePreparer(cloner)
+	app.SetExecutablePath(execPath)
 
 	code := app.Run([]string{"run", "daemon", "--repo", "owner/repo", "--dir", targetDir, "--detach", "--max-parallel-tasks", "2"})
 	if code != 0 {
@@ -1432,6 +1501,14 @@ func TestRunDaemonDetachStartsOneWorkerPerParallelTask(t *testing.T) {
 	}
 	if len(starter.reqs) != 2 {
 		t.Fatalf("starter requests = %d, want 2", len(starter.reqs))
+	}
+	for _, req := range starter.reqs {
+		if req.Name != execPath {
+			t.Fatalf("worker command = %q, want %q", req.Name, execPath)
+		}
+		if len(req.Args) < 2 || !reflect.DeepEqual(req.Args[:2], []string{"run", "daemon"}) {
+			t.Fatalf("worker args = %#v, want run daemon entrypoint", req.Args)
+		}
 	}
 	if starter.reqs[0].Dir == starter.reqs[1].Dir {
 		t.Fatalf("daemon worker dirs should differ, got %q", starter.reqs[0].Dir)
@@ -1476,10 +1553,12 @@ func TestRunDaemonDetachStartsThreeWorkersWhenRequested(t *testing.T) {
 	starter := &recordingDetachedStarter{pid: 31337}
 	cloner := &recordingBatchClonePreparer{}
 	targetDir := t.TempDir()
+	execPath := filepath.Join(targetDir, "orchestrator")
 	var out strings.Builder
 	app := NewApp(&out, &strings.Builder{})
 	app.SetDetachedStarter(starter)
 	app.SetBatchClonePreparer(cloner)
+	app.SetExecutablePath(execPath)
 
 	code := app.Run([]string{"run", "daemon", "--repo", "owner/repo", "--dir", targetDir, "--detach", "--max-parallel-tasks", "3"})
 	if code != 0 {
@@ -1490,6 +1569,14 @@ func TestRunDaemonDetachStartsThreeWorkersWhenRequested(t *testing.T) {
 	}
 	if len(cloner.targetDirs) != 3 {
 		t.Fatalf("clone preparations = %d, want 3", len(cloner.targetDirs))
+	}
+	for _, req := range starter.reqs {
+		if req.Name != execPath {
+			t.Fatalf("worker command = %q, want %q", req.Name, execPath)
+		}
+		if len(req.Args) < 2 || !reflect.DeepEqual(req.Args[:2], []string{"run", "daemon"}) {
+			t.Fatalf("worker args = %#v, want run daemon entrypoint", req.Args)
+		}
 	}
 	for _, workerID := range []string{"1", "2", "3"} {
 		workerDir := filepath.Join(targetDir, ".orchestrator", "workers", "daemon-"+workerID)

--- a/internal/cli/autonomous_session.go
+++ b/internal/cli/autonomous_session.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/podlodka-ai-club/steam-hammer/internal/core/orchestration"
+)
+
+type nativeSessionTracker struct {
+	path  string
+	label string
+	key   string
+}
+
+func startNativeSessionTracker(path, label, key string) nativeSessionTracker {
+	tracker := nativeSessionTracker{
+		path:  strings.TrimSpace(path),
+		label: strings.TrimSpace(label),
+		key:   strings.TrimSpace(key),
+	}
+	if tracker.path != "" {
+		tracker.write(nil, true, false)
+	}
+	return tracker
+}
+
+func (t nativeSessionTracker) finish(state *orchestration.TrackedState, exitCode int) {
+	if t.path == "" {
+		return
+	}
+	t.write(state, false, exitCode != 0)
+}
+
+func (t nativeSessionTracker) write(state *orchestration.TrackedState, running, failed bool) {
+	if t.path == "" {
+		return
+	}
+	persisted, err := loadAutonomousSessionState(t.path)
+	if err != nil {
+		persisted = orchestration.State{ProcessedIssues: map[string]json.RawMessage{}}
+	}
+	if persisted.ProcessedIssues == nil {
+		persisted.ProcessedIssues = map[string]json.RawMessage{}
+	}
+	if persisted.Checkpoint == nil {
+		persisted.Checkpoint = &orchestration.Checkpoint{}
+	}
+	checkpoint := persisted.Checkpoint
+	checkpoint.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if running {
+		checkpoint.Phase = "running"
+		checkpoint.Current = t.label
+		checkpoint.Done = nil
+		checkpoint.Next = []string{"wait for completion"}
+		checkpoint.IssuePRActions = nil
+		checkpoint.InProgress = []string{t.label}
+		checkpoint.Blockers = nil
+		checkpoint.NextCheckpoint = "when the current worker finishes"
+		checkpoint.Counts.Processed = len(persisted.ProcessedIssues)
+		_ = saveAutonomousSessionState(t.path, persisted)
+		return
+	}
+
+	checkpoint.Phase = "completed"
+	checkpoint.Current = "Idle between autonomous runs"
+	checkpoint.InProgress = nil
+	checkpoint.NextCheckpoint = "on the next worker run"
+	checkpoint.Done = nil
+	checkpoint.Next = nil
+	checkpoint.IssuePRActions = nil
+	checkpoint.Blockers = nil
+
+	if state != nil {
+		if raw, err := json.Marshal(state); err == nil {
+			if t.key != "" {
+				persisted.ProcessedIssues[t.key] = raw
+			}
+		}
+		checkpoint.Done = []string{nativeSessionDoneSummary(t.label, *state)}
+		if next := nativeSessionNextSummary(*state); next != "" {
+			checkpoint.Next = []string{next}
+		}
+		if action := nativeSessionActionSummary(*state); action != "" {
+			checkpoint.IssuePRActions = []string{action}
+		}
+		if blocker := strings.TrimSpace(state.Error); blocker != "" {
+			checkpoint.Blockers = []string{blocker}
+		}
+	}
+	checkpoint.Counts.Processed = len(persisted.ProcessedIssues)
+	if failed {
+		checkpoint.Counts.Failures = 1
+	} else {
+		checkpoint.Counts.Failures = 0
+	}
+	_ = saveAutonomousSessionState(t.path, persisted)
+}
+
+func loadAutonomousSessionState(path string) (orchestration.State, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return orchestration.State{ProcessedIssues: map[string]json.RawMessage{}}, nil
+		}
+		return orchestration.State{}, err
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return orchestration.State{ProcessedIssues: map[string]json.RawMessage{}}, nil
+	}
+	return orchestration.ParseState(raw)
+}
+
+func saveAutonomousSessionState(path string, state orchestration.State) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if state.ProcessedIssues == nil {
+		state.ProcessedIssues = map[string]json.RawMessage{}
+	}
+	directory := filepath.Dir(path)
+	if directory == "" {
+		directory = "."
+	}
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("failed to create autonomous session directory %s: %w", directory, err)
+	}
+	encoded, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode autonomous session file %s: %w", path, err)
+	}
+	encoded = append(encoded, '\n')
+	return os.WriteFile(path, encoded, 0o644)
+}
+
+func nativeSessionDoneSummary(label string, state orchestration.TrackedState) string {
+	status := strings.TrimSpace(state.Status)
+	if status == "" {
+		return label
+	}
+	return fmt.Sprintf("%s (%s)", label, status)
+}
+
+func nativeSessionNextSummary(state orchestration.TrackedState) string {
+	return nativeSessionHumanize(state.NextAction)
+}
+
+func nativeSessionActionSummary(state orchestration.TrackedState) string {
+	status := strings.TrimSpace(state.Status)
+	taskType := strings.TrimSpace(state.TaskType)
+	if taskType == "issue" && status == orchestration.StatusReadyForReview {
+		if state.PR != nil && *state.PR > 0 {
+			return fmt.Sprintf("prepared PR #%d for review", *state.PR)
+		}
+		return "prepared issue for review"
+	}
+	if taskType == "pr" && status == orchestration.StatusWaitingForCI {
+		return "pushed PR updates and waiting for CI"
+	}
+	if status == "" {
+		return ""
+	}
+	return nativeSessionHumanize(status)
+}
+
+func nativeSessionHumanize(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.ReplaceAll(value, "_", " ")
+	value = strings.ReplaceAll(value, "-", " ")
+	return value
+}

--- a/internal/cli/command_run.go
+++ b/internal/cli/command_run.go
@@ -1352,7 +1352,7 @@ func (a *App) runIssue(ctx context.Context, args []string) int {
 	syncStrategy := fs.String("sync-strategy", "", "reused branch sync strategy: rebase or merge")
 	detach := fs.Bool("detach", false, "start the worker in the background and write logs/state to a predictable path")
 	workerDir := fs.String("worker-dir", "", "directory that stores detached worker state")
-	_ = fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
+	autonomousSessionFile := fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
 
 	if err := fs.Parse(args); err != nil {
 		return flagExitCode(err)
@@ -1389,6 +1389,7 @@ func (a *App) runIssue(ctx context.Context, args []string) int {
 		noSyncReusedBranch:   *noSyncReusedBranch,
 		syncStrategy:         *syncStrategy,
 		detach:               *detach,
+		sessionPath:          strings.TrimSpace(*autonomousSessionFile),
 	}); handled {
 		return code
 	}
@@ -1474,7 +1475,7 @@ func (a *App) runPR(ctx context.Context, args []string) int {
 	syncStrategy := fs.String("sync-strategy", "", "reused branch sync strategy: rebase or merge")
 	detach := fs.Bool("detach", false, "start the worker in the background and write logs/state to a predictable path")
 	workerDir := fs.String("worker-dir", "", "directory that stores detached worker state")
-	_ = fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
+	autonomousSessionFile := fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
 
 	if err := fs.Parse(args); err != nil {
 		return flagExitCode(err)
@@ -1504,6 +1505,7 @@ func (a *App) runPR(ctx context.Context, args []string) int {
 		conflictRecoveryOnly: *conflictRecoveryOnly,
 		syncStrategy:         *syncStrategy,
 		detach:               *detach,
+		sessionPath:          strings.TrimSpace(*autonomousSessionFile),
 	}); ok {
 		return code
 	}

--- a/internal/cli/command_run.go
+++ b/internal/cli/command_run.go
@@ -81,76 +81,96 @@ func (a *App) runRun(ctx context.Context, args []string) int {
 func buildIssuePythonArgs(script string, opts commonOptions, id int, base string, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch bool, syncStrategy string, fs flagState) []string {
 	pythonArgs := []string{script, "--issue", strconv.Itoa(id)}
 	pythonArgs = appendCommonPythonArgs(pythonArgs, opts)
+	return appendIssueRunArgs(pythonArgs, base, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch, syncStrategy, fs)
+}
+
+func buildIssueCLIArgs(opts commonOptions, id int, base string, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch bool, syncStrategy string, fs flagState) []string {
+	args := []string{"run", "issue", "--id", strconv.Itoa(id)}
+	args = appendCommonPythonArgs(args, opts)
+	return appendIssueRunArgs(args, base, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch, syncStrategy, fs)
+}
+
+func appendIssueRunArgs(args []string, base string, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch bool, syncStrategy string, fs flagState) []string {
 	if base != "" {
-		pythonArgs = append(pythonArgs, "--base", base)
+		args = append(args, "--base", base)
 	}
 	if includeEmpty {
-		pythonArgs = append(pythonArgs, "--include-empty")
+		args = append(args, "--include-empty")
 	}
 	if stopOnError {
-		pythonArgs = append(pythonArgs, "--stop-on-error")
+		args = append(args, "--stop-on-error")
 	}
 	if failOnExisting {
-		pythonArgs = append(pythonArgs, "--fail-on-existing")
+		args = append(args, "--fail-on-existing")
 	}
 	if forceIssueFlow {
-		pythonArgs = append(pythonArgs, "--force-issue-flow")
+		args = append(args, "--force-issue-flow")
 	}
 	if noSkipIfPRExists {
-		pythonArgs = append(pythonArgs, "--no-skip-if-pr-exists")
+		args = append(args, "--no-skip-if-pr-exists")
 	} else if fs.wasPassed("skip-if-pr-exists") && skipIfPRExists {
-		pythonArgs = append(pythonArgs, "--skip-if-pr-exists")
+		args = append(args, "--skip-if-pr-exists")
 	} else if !skipIfPRExists {
-		pythonArgs = append(pythonArgs, "--no-skip-if-pr-exists")
+		args = append(args, "--no-skip-if-pr-exists")
 	}
 	if noSkipIfBranchExists {
-		pythonArgs = append(pythonArgs, "--no-skip-if-branch-exists")
+		args = append(args, "--no-skip-if-branch-exists")
 	} else if fs.wasPassed("skip-if-branch-exists") && skipIfBranchExists {
-		pythonArgs = append(pythonArgs, "--skip-if-branch-exists")
+		args = append(args, "--skip-if-branch-exists")
 	} else if !skipIfBranchExists {
-		pythonArgs = append(pythonArgs, "--no-skip-if-branch-exists")
+		args = append(args, "--no-skip-if-branch-exists")
 	}
 	if forceReprocess {
-		pythonArgs = append(pythonArgs, "--force-reprocess")
+		args = append(args, "--force-reprocess")
 	}
 	if conflictRecoveryOnly {
-		pythonArgs = append(pythonArgs, "--conflict-recovery-only")
+		args = append(args, "--conflict-recovery-only")
 	}
 	if noSyncReusedBranch {
-		pythonArgs = append(pythonArgs, "--no-sync-reused-branch")
+		args = append(args, "--no-sync-reused-branch")
 	} else if fs.wasPassed("sync-reused-branch") && syncReusedBranch {
-		pythonArgs = append(pythonArgs, "--sync-reused-branch")
+		args = append(args, "--sync-reused-branch")
 	} else if !syncReusedBranch {
-		pythonArgs = append(pythonArgs, "--no-sync-reused-branch")
+		args = append(args, "--no-sync-reused-branch")
 	}
 	if syncStrategy != "" {
-		pythonArgs = append(pythonArgs, "--sync-strategy", syncStrategy)
+		args = append(args, "--sync-strategy", syncStrategy)
 	}
-	return pythonArgs
+	return args
 }
 
 func buildPRPythonArgs(script string, opts commonOptions, id int, allowBranchSwitch, isolateWorktree, postSummary bool, followupPrefix string, conflictRecoveryOnly bool, syncStrategy string) []string {
 	pythonArgs := []string{script, "--pr", strconv.Itoa(id), "--from-review-comments"}
 	pythonArgs = appendCommonPythonArgs(pythonArgs, opts)
+	return appendPRRunArgs(pythonArgs, allowBranchSwitch, isolateWorktree, postSummary, followupPrefix, conflictRecoveryOnly, syncStrategy)
+}
+
+func buildPRCLIArgs(opts commonOptions, id int, allowBranchSwitch, isolateWorktree, postSummary bool, followupPrefix string, conflictRecoveryOnly bool, syncStrategy string) []string {
+	args := []string{"run", "pr", "--id", strconv.Itoa(id)}
+	args = appendCommonPythonArgs(args, opts)
+	return appendPRRunArgs(args, allowBranchSwitch, isolateWorktree, postSummary, followupPrefix, conflictRecoveryOnly, syncStrategy)
+}
+
+func appendPRRunArgs(args []string, allowBranchSwitch, isolateWorktree, postSummary bool, followupPrefix string, conflictRecoveryOnly bool, syncStrategy string) []string {
 	if allowBranchSwitch {
-		pythonArgs = append(pythonArgs, "--allow-pr-branch-switch")
+		args = append(args, "--allow-pr-branch-switch")
 	}
 	if isolateWorktree {
-		pythonArgs = append(pythonArgs, "--isolate-worktree")
+		args = append(args, "--isolate-worktree")
 	}
 	if postSummary {
-		pythonArgs = append(pythonArgs, "--post-pr-summary")
+		args = append(args, "--post-pr-summary")
 	}
 	if followupPrefix != "" {
-		pythonArgs = append(pythonArgs, "--pr-followup-branch-prefix", followupPrefix)
+		args = append(args, "--pr-followup-branch-prefix", followupPrefix)
 	}
 	if syncStrategy != "" {
-		pythonArgs = append(pythonArgs, "--sync-strategy", syncStrategy)
+		args = append(args, "--sync-strategy", syncStrategy)
 	}
 	if conflictRecoveryOnly {
-		pythonArgs = append(pythonArgs, "--conflict-recovery-only")
+		args = append(args, "--conflict-recovery-only")
 	}
-	return pythonArgs
+	return args
 }
 
 func appendAutonomousSessionFile(args []string, sessionPath string) []string {
@@ -244,6 +264,63 @@ func buildDaemonPythonArgs(script string, opts commonOptions, state string, limi
 	return pythonArgs
 }
 
+func buildDaemonCLIArgs(opts commonOptions, state string, limit int, base string, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, syncReusedBranch, noSyncReusedBranch bool, syncStrategy, sessionPath string, postBatchVerify, createFollowupIssue bool, fs flagState) []string {
+	args := []string{"run", "daemon", "--state", state, "--limit", strconv.Itoa(limit)}
+	args = appendCommonPythonArgs(args, opts)
+	if base != "" {
+		args = append(args, "--base", base)
+	}
+	if includeEmpty {
+		args = append(args, "--include-empty")
+	}
+	if stopOnError {
+		args = append(args, "--stop-on-error")
+	}
+	if failOnExisting {
+		args = append(args, "--fail-on-existing")
+	}
+	if forceIssueFlow {
+		args = append(args, "--force-issue-flow")
+	}
+	if noSkipIfPRExists {
+		args = append(args, "--no-skip-if-pr-exists")
+	} else if fs.wasPassed("skip-if-pr-exists") && skipIfPRExists {
+		args = append(args, "--skip-if-pr-exists")
+	} else if !skipIfPRExists {
+		args = append(args, "--no-skip-if-pr-exists")
+	}
+	if noSkipIfBranchExists {
+		args = append(args, "--no-skip-if-branch-exists")
+	} else if fs.wasPassed("skip-if-branch-exists") && skipIfBranchExists {
+		args = append(args, "--skip-if-branch-exists")
+	} else if !skipIfBranchExists {
+		args = append(args, "--no-skip-if-branch-exists")
+	}
+	if forceReprocess {
+		args = append(args, "--force-reprocess")
+	}
+	if noSyncReusedBranch {
+		args = append(args, "--no-sync-reused-branch")
+	} else if fs.wasPassed("sync-reused-branch") && syncReusedBranch {
+		args = append(args, "--sync-reused-branch")
+	} else if !syncReusedBranch {
+		args = append(args, "--no-sync-reused-branch")
+	}
+	if syncStrategy != "" {
+		args = append(args, "--sync-strategy", syncStrategy)
+	}
+	if sessionPath != "" {
+		args = append(args, "--autonomous-session-file", sessionPath)
+	}
+	if postBatchVerify {
+		args = append(args, "--post-batch-verify")
+	}
+	if createFollowupIssue {
+		args = append(args, "--create-followup-issue")
+	}
+	return args
+}
+
 func defaultSourceDir(configuredDir string) string {
 	if strings.TrimSpace(configuredDir) != "" {
 		return configuredDir
@@ -300,6 +377,13 @@ func daemonWorkerName(slot int) string {
 		return "daemon"
 	}
 	return workerName("daemon", strconv.Itoa(slot))
+}
+
+func workerRuntimeLabel(name string) string {
+	if name == "python3" {
+		return "python runner"
+	}
+	return "orchestrator worker"
 }
 
 func shouldUseGoDaemonPolicy(opts commonOptions, lifecycle daemonLifecycle) bool {
@@ -360,9 +444,104 @@ type daemonParallelPreparedWorker struct {
 	name       string
 	issueID    int
 	opts       commonOptions
+	command    workerLaunchCommand
 	pythonArgs []string
 	workerPath detachedWorkerPaths
 	cleanup    func()
+}
+
+type workerLaunchCommand struct {
+	name           string
+	args           []string
+	fallbackReason string
+}
+
+func (a *App) currentExecutable() (string, error) {
+	if a.executablePath == nil {
+		return "", fmt.Errorf("orchestrator executable path is not configured")
+	}
+	return a.executablePath()
+}
+
+func (a *App) buildBatchWorkerLaunchCommand(ctx context.Context, opts commonOptions, id int, base string, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch bool, syncStrategy string, fs flagState) workerLaunchCommand {
+	pythonIssue := workerLaunchCommand{
+		name: "python3",
+		args: buildIssuePythonArgs(a.runtime.RunnerScript(), opts, id, base, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch, syncStrategy, fs),
+	}
+	if strings.TrimSpace(*opts.repo) == "" {
+		pythonIssue.fallbackReason = "native worker dispatch requires --repo"
+		return pythonIssue
+	}
+	if a.issueLifecycle == nil {
+		pythonIssue.fallbackReason = "native worker dispatch requires issue lifecycle dependencies"
+		return pythonIssue
+	}
+
+	issue, err := a.issueLifecycle.FetchIssue(ctx, strings.TrimSpace(*opts.repo), id)
+	if err != nil {
+		pythonIssue.fallbackReason = fmt.Sprintf("failed to inspect issue #%d for native dispatch: %v", id, err)
+		return pythonIssue
+	}
+	comments, err := a.issueLifecycle.ListIssueComments(ctx, strings.TrimSpace(*opts.repo), id)
+	if err != nil {
+		pythonIssue.fallbackReason = fmt.Sprintf("failed to inspect issue #%d comments for native dispatch: %v", id, err)
+		return pythonIssue
+	}
+	trackerComments := make([]orchestration.TrackerComment, 0, len(comments))
+	for _, comment := range comments {
+		trackerComments = append(trackerComments, orchestration.TrackerComment{ID: comment.ID, CreatedAt: comment.CreatedAt, HTMLURL: comment.HTMLURL, Body: comment.Body})
+	}
+	recoveredState, _ := orchestration.SelectLatestParseableOrchestrationState(trackerComments, fmt.Sprintf("issue #%d", id))
+	linkedPR, err := a.issueLifecycle.FindOpenPullRequestForIssue(ctx, strings.TrimSpace(*opts.repo), issue)
+	if err != nil {
+		pythonIssue.fallbackReason = fmt.Sprintf("failed to inspect linked PR for issue #%d: %v", id, err)
+		return pythonIssue
+	}
+	decision := orchestration.ChooseExecutionMode(id, linkedPRNumber(linkedPR), forceIssueFlow, parsedStatePayload(recoveredState), nil)
+
+	if decision.Mode == orchestration.ExecutionModePRReview && linkedPR != nil {
+		pythonPR := workerLaunchCommand{
+			name: "python3",
+			args: buildPRPythonArgs(a.runtime.RunnerScript(), opts, linkedPR.Number, false, false, false, "", false, ""),
+		}
+		if reason := nativePRFallbackReason(nativePROptions{prID: linkedPR.Number, common: opts}); reason != "" {
+			pythonPR.fallbackReason = reason
+			return pythonPR
+		}
+		execPath, err := a.currentExecutable()
+		if err != nil {
+			pythonPR.fallbackReason = fmt.Sprintf("failed to resolve orchestrator executable: %v", err)
+			return pythonPR
+		}
+		return workerLaunchCommand{name: execPath, args: buildPRCLIArgs(opts, linkedPR.Number, false, false, false, "", false, "")}
+	}
+
+	if reason := nativeIssueFallbackReason(nativeIssueOptions{
+		issueID:              id,
+		common:               opts,
+		base:                 base,
+		includeEmpty:         includeEmpty,
+		failOnExisting:       failOnExisting,
+		forceIssueFlow:       forceIssueFlow,
+		skipIfPRExists:       skipIfPRExists,
+		noSkipIfPRExists:     noSkipIfPRExists,
+		skipIfBranchExists:   skipIfBranchExists,
+		noSkipIfBranchExists: noSkipIfBranchExists,
+		forceReprocess:       forceReprocess,
+		conflictRecoveryOnly: conflictRecoveryOnly,
+		syncReusedBranch:     syncReusedBranch,
+		noSyncReusedBranch:   noSyncReusedBranch,
+		syncStrategy:         syncStrategy,
+	}); reason != "" {
+		pythonIssue.fallbackReason = reason
+		return pythonIssue
+	}
+	execPath, err := a.currentExecutable()
+	if err != nil {
+		pythonIssue.fallbackReason = fmt.Sprintf("failed to resolve orchestrator executable: %v", err)
+		return pythonIssue
+	}
+	return workerLaunchCommand{name: execPath, args: buildIssueCLIArgs(opts, id, base, includeEmpty, stopOnError, failOnExisting, forceIssueFlow, skipIfPRExists, noSkipIfPRExists, skipIfBranchExists, noSkipIfBranchExists, forceReprocess, conflictRecoveryOnly, syncReusedBranch, noSyncReusedBranch, syncStrategy, fs)}
 }
 
 func (a *App) selectDaemonIssues(ctx context.Context, config daemonParallelConfig, handled daemonHandledState) ([]daemonSelectedIssue, error) {
@@ -481,7 +660,7 @@ func daemonPayloadString(payload map[string]any, key string) string {
 	return strings.TrimSpace(value)
 }
 
-func (a *App) prepareParallelDaemonWorker(config daemonParallelConfig, issue daemonSelectedIssue, sessionPath string) (daemonParallelPreparedWorker, error) {
+func (a *App) prepareParallelDaemonWorker(ctx context.Context, config daemonParallelConfig, issue daemonSelectedIssue, sessionPath string) (daemonParallelPreparedWorker, error) {
 	workerOpts := config.opts
 	if config.detach {
 		workerPaths, err := resolveDetachedWorkerPaths(config.workerDir, *config.opts.dir, "daemon", strings.TrimPrefix(issue.workerName, "daemon-"))
@@ -497,26 +676,11 @@ func (a *App) prepareParallelDaemonWorker(config daemonParallelConfig, issue dae
 			name:    issue.workerName,
 			issueID: issue.issueID,
 			opts:    workerOpts,
-			pythonArgs: appendAutonomousSessionFile(buildIssuePythonArgs(
-				a.runtime.RunnerScript(),
-				workerOpts,
-				issue.issueID,
-				config.base,
-				config.includeEmpty,
-				config.stopOnError,
-				config.failOnExisting,
-				config.forceIssueFlow,
-				config.skipIfPRExists,
-				config.noSkipIfPRExists,
-				config.skipIfBranchExists,
-				config.noSkipIfBranchExists,
-				config.forceReprocess,
-				false,
-				config.syncReusedBranch,
-				config.noSyncReusedBranch,
-				config.syncStrategy,
-				config.flags,
-			), workerPaths.SessionPath),
+			command: func() workerLaunchCommand {
+				command := a.buildBatchWorkerLaunchCommand(ctx, workerOpts, issue.issueID, config.base, config.includeEmpty, config.stopOnError, config.failOnExisting, config.forceIssueFlow, config.skipIfPRExists, config.noSkipIfPRExists, config.skipIfBranchExists, config.noSkipIfBranchExists, config.forceReprocess, false, config.syncReusedBranch, config.noSyncReusedBranch, config.syncStrategy, config.flags)
+				command.args = appendAutonomousSessionFile(command.args, workerPaths.SessionPath)
+				return command
+			}(),
 			workerPath: workerPaths,
 		}, nil
 	}
@@ -545,26 +709,11 @@ func (a *App) prepareParallelDaemonWorker(config daemonParallelConfig, issue dae
 		name:    issue.workerName,
 		issueID: issue.issueID,
 		opts:    workerOpts,
-		pythonArgs: appendAutonomousSessionFile(buildIssuePythonArgs(
-			a.runtime.RunnerScript(),
-			workerOpts,
-			issue.issueID,
-			config.base,
-			config.includeEmpty,
-			config.stopOnError,
-			config.failOnExisting,
-			config.forceIssueFlow,
-			config.skipIfPRExists,
-			config.noSkipIfPRExists,
-			config.skipIfBranchExists,
-			config.noSkipIfBranchExists,
-			config.forceReprocess,
-			false,
-			config.syncReusedBranch,
-			config.noSyncReusedBranch,
-			config.syncStrategy,
-			config.flags,
-		), workerSessionPath),
+		command: func() workerLaunchCommand {
+			command := a.buildBatchWorkerLaunchCommand(ctx, workerOpts, issue.issueID, config.base, config.includeEmpty, config.stopOnError, config.failOnExisting, config.forceIssueFlow, config.skipIfPRExists, config.noSkipIfPRExists, config.skipIfBranchExists, config.noSkipIfBranchExists, config.forceReprocess, false, config.syncReusedBranch, config.noSyncReusedBranch, config.syncStrategy, config.flags)
+			command.args = appendAutonomousSessionFile(command.args, workerSessionPath)
+			return command
+		}(),
 		cleanup: cleanup,
 	}, nil
 }
@@ -608,7 +757,7 @@ func (a *App) runParallelDaemon(ctx context.Context, config daemonParallelConfig
 		if !selectionFailed {
 			for _, issue := range selected {
 				handled.signatures[issue.issueID] = issue.signature
-				worker, err := a.prepareParallelDaemonWorker(config, issue, config.sessionPath)
+				worker, err := a.prepareParallelDaemonWorker(ctx, config, issue, config.sessionPath)
 				if err != nil {
 					_, _ = fmt.Fprintf(a.err, "orchestrator: %v\n", err)
 					lastCode = 1
@@ -637,10 +786,13 @@ func (a *App) runParallelDaemon(ctx context.Context, config daemonParallelConfig
 			var mu sync.Mutex
 			for _, worker := range preparedWorkers {
 				worker := worker
+				if worker.command.fallbackReason != "" {
+					_, _ = fmt.Fprintf(a.err, "orchestrator: falling back to python worker for issue #%d: %s\n", worker.issueID, worker.command.fallbackReason)
+				}
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					code := a.runPython(cycleCtx, worker.pythonArgs)
+					code := a.runSubprocess(cycleCtx, workerRuntimeLabel(worker.command.name), worker.command.name, worker.command.args)
 					if worker.cleanup != nil {
 						worker.cleanup()
 					}
@@ -729,27 +881,12 @@ func (a *App) runSerialDaemon(ctx context.Context, config daemonParallelConfig) 
 			cycleCode := 0
 			for _, issue := range selected {
 				handled.signatures[issue.issueID] = issue.signature
-				pythonArgs := appendAutonomousSessionFile(buildIssuePythonArgs(
-					a.runtime.RunnerScript(),
-					config.opts,
-					issue.issueID,
-					config.base,
-					config.includeEmpty,
-					config.stopOnError,
-					config.failOnExisting,
-					config.forceIssueFlow,
-					config.skipIfPRExists,
-					config.noSkipIfPRExists,
-					config.skipIfBranchExists,
-					config.noSkipIfBranchExists,
-					config.forceReprocess,
-					false,
-					config.syncReusedBranch,
-					config.noSyncReusedBranch,
-					config.syncStrategy,
-					config.flags,
-				), config.sessionPath)
-				code := a.runPython(ctx, pythonArgs)
+				command := a.buildBatchWorkerLaunchCommand(ctx, config.opts, issue.issueID, config.base, config.includeEmpty, config.stopOnError, config.failOnExisting, config.forceIssueFlow, config.skipIfPRExists, config.noSkipIfPRExists, config.skipIfBranchExists, config.noSkipIfBranchExists, config.forceReprocess, false, config.syncReusedBranch, config.noSyncReusedBranch, config.syncStrategy, config.flags)
+				if command.fallbackReason != "" {
+					_, _ = fmt.Fprintf(a.err, "orchestrator: falling back to python worker for issue #%d: %s\n", issue.issueID, command.fallbackReason)
+				}
+				command.args = appendAutonomousSessionFile(command.args, config.sessionPath)
+				code := a.runSubprocess(ctx, workerRuntimeLabel(command.name), command.name, command.args)
 				if code != 0 && cycleCode == 0 {
 					cycleCode = code
 				}
@@ -834,6 +971,7 @@ func (a *App) runDaemon(ctx context.Context, args []string) int {
 	createFollowupIssue := fs.Bool("create-followup-issue", false, a.runtime.FollowUpIssueFlagDescription("post-batch verification"))
 	detach := fs.Bool("detach", false, "start the worker in the background and write logs/state to a predictable path")
 	workerDir := fs.String("worker-dir", "", "directory that stores detached worker state")
+	autonomousSessionFile := fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
 
 	if err := fs.Parse(args); err != nil {
 		return flagExitCode(err)
@@ -872,6 +1010,11 @@ func (a *App) runDaemon(ctx context.Context, args []string) int {
 		effectiveMaxCycles = 1
 	}
 	if *detach {
+		execPath, err := a.currentExecutable()
+		if err != nil {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to resolve orchestrator executable: %v\n", err)
+			return 1
+		}
 		lastCode := 0
 		for workerIndex := 1; workerIndex <= *maxParallelTasks; workerIndex++ {
 			workerID := ""
@@ -895,8 +1038,7 @@ func (a *App) runDaemon(ctx context.Context, args []string) int {
 				continue
 			}
 			daemonOpts := withCommonOptionsDir(opts, clonePath)
-			workerArgs := buildDaemonPythonArgs(
-				a.runtime.RunnerScript(),
+			workerArgs := buildDaemonCLIArgs(
 				daemonOpts,
 				*state,
 				*limit,
@@ -918,13 +1060,14 @@ func (a *App) runDaemon(ctx context.Context, args []string) int {
 				*createFollowupIssue,
 				flags,
 			)
+			workerArgs = append(workerArgs, "--max-parallel-tasks", "1", "--max-cycles", "1")
 			state := detachedWorkerStateFromOptions(
 				workerLabel,
 				"run daemon",
 				"daemon",
 				workerID,
 				daemonOpts,
-				append([]string{"python3"}, workerArgs...),
+				append([]string{execPath}, workerArgs...),
 				workerPaths,
 			)
 			state.WorkDir = clonePath
@@ -938,15 +1081,21 @@ func (a *App) runDaemon(ctx context.Context, args []string) int {
 		return lastCode
 	}
 
-	if !shouldUseGoDaemonPolicy(opts, a.daemon) {
+	sessionPath := strings.TrimSpace(*autonomousSessionFile)
+	cleanupSession := func() {}
+	if sessionPath == "" {
 		sessionFile, err := os.CreateTemp("", "orchestrator-daemon-session-*.json")
 		if err != nil {
 			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to create daemon session file: %v\n", err)
 			return 1
 		}
-		sessionPath := sessionFile.Name()
+		sessionPath = sessionFile.Name()
 		_ = sessionFile.Close()
-		defer os.Remove(sessionPath)
+		cleanupSession = func() { _ = os.Remove(sessionPath) }
+	}
+	defer cleanupSession()
+
+	if !shouldUseGoDaemonPolicy(opts, a.daemon) {
 		pythonArgs := buildDaemonPythonArgs(a.runtime.RunnerScript(), opts, *state, *limit, base, *includeEmpty, *stopOnError, *failOnExisting, *forceIssueFlow, *skipIfPRExists, *noSkipIfPRExists, *skipIfBranchExists, *noSkipIfBranchExists, *forceReprocess, *syncReusedBranch, *noSyncReusedBranch, *syncStrategy, sessionPath, *postBatchVerify, *createFollowupIssue, flags)
 
 		cycles := 0
@@ -978,15 +1127,6 @@ func (a *App) runDaemon(ctx context.Context, args []string) int {
 			}
 		}
 	}
-
-	sessionFile, err := os.CreateTemp("", "orchestrator-daemon-session-*.json")
-	if err != nil {
-		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to create daemon session file: %v\n", err)
-		return 1
-	}
-	sessionPath := sessionFile.Name()
-	_ = sessionFile.Close()
-	defer os.Remove(sessionPath)
 
 	if *maxParallelTasks > 1 {
 		return a.runParallelDaemon(ctx, daemonParallelConfig{
@@ -1119,8 +1259,8 @@ func (a *App) runBatch(ctx context.Context, args []string) int {
 			}
 			issueOpts = withCommonOptionsDir(issueOpts, clonePath)
 		}
-		pythonArgs := buildIssuePythonArgs(
-			a.runtime.RunnerScript(),
+		command := a.buildBatchWorkerLaunchCommand(
+			ctx,
 			issueOpts,
 			id,
 			base,
@@ -1139,6 +1279,9 @@ func (a *App) runBatch(ctx context.Context, args []string) int {
 			*syncStrategy,
 			flags,
 		)
+		if command.fallbackReason != "" {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: falling back to python worker for issue #%d: %s\n", id, command.fallbackReason)
+		}
 		if *detach {
 			state := detachedWorkerStateFromOptions(
 				workerName("issue", strconv.Itoa(id)),
@@ -1146,7 +1289,7 @@ func (a *App) runBatch(ctx context.Context, args []string) int {
 				"issue",
 				strconv.Itoa(id),
 				issueOpts,
-				append([]string{"python3"}, pythonArgs...),
+				append([]string{command.name}, command.args...),
 				workerPaths,
 			)
 			state.WorkDir = clonePath
@@ -1169,7 +1312,7 @@ func (a *App) runBatch(ctx context.Context, args []string) int {
 			}
 			continue
 		}
-		code := a.runPython(ctx, pythonArgs)
+		code := a.runSubprocess(ctx, workerRuntimeLabel(command.name), command.name, command.args)
 		if code != 0 {
 			if *stopOnError {
 				return code
@@ -1209,6 +1352,7 @@ func (a *App) runIssue(ctx context.Context, args []string) int {
 	syncStrategy := fs.String("sync-strategy", "", "reused branch sync strategy: rebase or merge")
 	detach := fs.Bool("detach", false, "start the worker in the background and write logs/state to a predictable path")
 	workerDir := fs.String("worker-dir", "", "directory that stores detached worker state")
+	_ = fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
 
 	if err := fs.Parse(args); err != nil {
 		return flagExitCode(err)
@@ -1330,6 +1474,7 @@ func (a *App) runPR(ctx context.Context, args []string) int {
 	syncStrategy := fs.String("sync-strategy", "", "reused branch sync strategy: rebase or merge")
 	detach := fs.Bool("detach", false, "start the worker in the background and write logs/state to a predictable path")
 	workerDir := fs.String("worker-dir", "", "directory that stores detached worker state")
+	_ = fs.String("autonomous-session-file", "", "internal autonomous session checkpoint path")
 
 	if err := fs.Parse(args); err != nil {
 		return flagExitCode(err)

--- a/internal/cli/issue_native.go
+++ b/internal/cli/issue_native.go
@@ -26,6 +26,7 @@ const (
 type nativeIssueOptions struct {
 	issueID              int
 	common               commonOptions
+	sessionPath          string
 	base                 string
 	includeEmpty         bool
 	failOnExisting       bool
@@ -89,7 +90,13 @@ func nativeIssueFallbackReason(opts nativeIssueOptions) string {
 	return ""
 }
 
-func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueOptions) int {
+func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueOptions) (exitCode int) {
+	tracker := startNativeSessionTracker(opts.sessionPath, fmt.Sprintf("issue #%d", opts.issueID), strconv.Itoa(opts.issueID))
+	var latestState *orchestration.TrackedState
+	defer func() {
+		tracker.finish(latestState, exitCode)
+	}()
+
 	issue, err := a.issueLifecycle.FetchIssue(ctx, repo, opts.issueID)
 	if err != nil {
 		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to fetch issue #%d: %v\n", opts.issueID, err)
@@ -248,6 +255,8 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 	branchLifecycle := orchestration.BranchLifecycleCreated
 	var reusedBranchSync *orchestration.ReusedBranchSyncVerdict
 	postState := func(state orchestration.TrackedState) {
+		copy := state
+		latestState = &copy
 		if err := a.safePostIssueState(ctx, repo, issue.Number, state); err != nil {
 			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post state for issue #%d: %v\n", issue.Number, err)
 		}

--- a/internal/cli/pr_native.go
+++ b/internal/cli/pr_native.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ type prReviewLifecycle interface {
 type nativePROptions struct {
 	prID                 int
 	common               commonOptions
+	sessionPath          string
 	allowBranchSwitch    bool
 	isolateWorktree      bool
 	postSummary          bool
@@ -92,7 +94,13 @@ func nativePRFallbackReason(opts nativePROptions) string {
 	return ""
 }
 
-func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions) int {
+func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions) (exitCode int) {
+	tracker := startNativeSessionTracker(opts.sessionPath, fmt.Sprintf("PR #%d", opts.prID), strconv.Itoa(opts.prID))
+	var latestState *orchestration.TrackedState
+	defer func() {
+		tracker.finish(latestState, exitCode)
+	}()
+
 	pullRequest, err := a.prLifecycle.FetchPullRequest(ctx, repo, opts.prID)
 	if err != nil {
 		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to fetch PR #%d: %v\n", opts.prID, err)
@@ -145,6 +153,8 @@ func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions
 	linkedIssues := a.loadLinkedIssueContext(ctx, repo, pullRequest)
 
 	postState := func(state orchestration.TrackedState) {
+		copy := state
+		latestState = &copy
 		if err := a.safePostPRState(ctx, repo, pullRequest.Number, state); err != nil {
 			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post state for PR #%d: %v\n", pullRequest.Number, err)
 		}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -115,14 +115,14 @@ func formatCommandOutput(output []byte) string {
 	return ": " + trimmed
 }
 
-func (a *App) runPython(ctx context.Context, args []string) int {
-	if err := a.runner.Run(ctx, "python3", args...); err != nil {
+func (a *App) runSubprocess(ctx context.Context, runtimeLabel, name string, args []string) int {
+	if err := a.runner.Run(ctx, name, args...); err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			_, _ = fmt.Fprintln(a.err, "orchestrator: python runner timed out")
+			_, _ = fmt.Fprintf(a.err, "orchestrator: %s timed out\n", runtimeLabel)
 			return 124
 		}
 		if errors.Is(ctx.Err(), context.Canceled) {
-			_, _ = fmt.Fprintln(a.err, "orchestrator: python runner canceled")
+			_, _ = fmt.Fprintf(a.err, "orchestrator: %s canceled\n", runtimeLabel)
 			return 130
 		}
 
@@ -130,13 +130,17 @@ func (a *App) runPython(ctx context.Context, args []string) int {
 		if errors.As(err, &exitErr) {
 			code := exitErr.ExitCode()
 			if code >= 0 {
-				_, _ = fmt.Fprintf(a.err, "orchestrator: python runner exited with code %d\n", code)
+				_, _ = fmt.Fprintf(a.err, "orchestrator: %s exited with code %d\n", runtimeLabel, code)
 				return code
 			}
 		}
 
-		_, _ = fmt.Fprintf(a.err, "orchestrator: python runner failed: %v\n", err)
+		_, _ = fmt.Fprintf(a.err, "orchestrator: %s failed: %v\n", runtimeLabel, err)
 		return 1
 	}
 	return 0
+}
+
+func (a *App) runPython(ctx context.Context, args []string) int {
+	return a.runSubprocess(ctx, "python runner", "python3", args)
 }


### PR DESCRIPTION
## Summary
- Routes daemon/batch workers through Go-native issue/PR entrypoints when the selected task is supported.
- Keeps explicit Python fallback reasons for unsupported dispatch paths.
- Preserves detached/autonomous session checkpoint visibility for native child workers.

## Verification
- `go test ./...`
- `python3 -m unittest discover -s tests -q`

Part of #243.
Closes #283