### PR TITLE
Fix issue #286: Child of #243: Implement Go-native issue --conflict-recovery-only command

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1107,6 +1107,217 @@ func TestRunIssueUsesGoNativeReusedBranchSyncPreflight(t *testing.T) {
 	}
 }
 
+func TestRunIssueConflictRecoveryOnlySyncsAndPushesWithoutAgent(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 0},
+		{ExitCode: 0},
+		{},
+		{},
+		{},
+		{Stdout: "abc123\n"},
+		{},
+		{Stdout: "def456\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+	}
+	agent := &fakeIssueAgentRunner{}
+	var out strings.Builder
+	app := NewApp(&out, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--conflict-recovery-only"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 0 {
+		t.Fatalf("agent call count = %d, want 0", agent.callCount)
+	}
+	if len(lifecycle.commentBodies[71]) != 1 {
+		t.Fatalf("comment bodies = %d, want 1", len(lifecycle.commentBodies[71]))
+	}
+	state, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][0])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody() error = %v", err)
+	}
+	if state.Status != orchestration.StatusWaitingForAuthor || state.Stage != "sync_branch" || state.NextAction != "inspect_conflict_recovery_result" {
+		t.Fatalf("state = %#v", state)
+	}
+	if state.BranchLifecycle != orchestration.BranchLifecycleReused {
+		t.Fatalf("branch lifecycle = %q, want reused", state.BranchLifecycle)
+	}
+	if state.ReusedBranchSync == nil || state.ReusedBranchSync.Status != orchestration.BranchSyncStatusSyncedCleanly || !state.ReusedBranchSync.Changed {
+		t.Fatalf("sync verdict = %#v", state.ReusedBranchSync)
+	}
+	if len(lifecycle.createdPRs) != 0 {
+		t.Fatalf("created PRs = %d, want 0", len(lifecycle.createdPRs))
+	}
+	wantCommands := []string{
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("show-ref", "--verify", "--quiet", "refs/heads/issue-fix/71-fix-runner"),
+		gitCommand("ls-remote", "--exit-code", "--heads", "origin", "issue-fix/71-fix-runner"),
+		gitCommand("checkout", "main"),
+		gitCommand("checkout", "issue-fix/71-fix-runner"),
+		gitCommand("fetch", "origin", "main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("rebase", "origin/main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("push", "-u", "--force-with-lease", "origin", "issue-fix/71-fix-runner"),
+	}
+	if !reflect.DeepEqual(shell.cmds, wantCommands) {
+		t.Fatalf("shell commands = %#v, want %#v", shell.cmds, wantCommands)
+	}
+	printed := out.String()
+	if !strings.Contains(printed, "Conflict recovery push result for branch 'issue-fix/71-fix-runner': pushed") || !strings.Contains(printed, "Conflict recovery result for branch 'issue-fix/71-fix-runner': synced cleanly") {
+		t.Fatalf("stdout = %q, want recovery summaries", printed)
+	}
+}
+
+func TestRunIssueConflictRecoveryOnlyNoopSkipsPush(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 0},
+		{ExitCode: 0},
+		{},
+		{},
+		{},
+		{Stdout: "abc123\n"},
+		{},
+		{Stdout: "abc123\n"},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+	}
+	agent := &fakeIssueAgentRunner{}
+	var out strings.Builder
+	app := NewApp(&out, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--conflict-recovery-only"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 0 {
+		t.Fatalf("agent call count = %d, want 0", agent.callCount)
+	}
+	if len(lifecycle.commentBodies[71]) != 1 {
+		t.Fatalf("comment bodies = %d, want 1", len(lifecycle.commentBodies[71]))
+	}
+	state, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][0])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody() error = %v", err)
+	}
+	if state.ReusedBranchSync == nil || state.ReusedBranchSync.Status != orchestration.BranchSyncStatusAlreadyCurrent || state.ReusedBranchSync.Changed {
+		t.Fatalf("sync verdict = %#v", state.ReusedBranchSync)
+	}
+	wantCommands := []string{
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("show-ref", "--verify", "--quiet", "refs/heads/issue-fix/71-fix-runner"),
+		gitCommand("ls-remote", "--exit-code", "--heads", "origin", "issue-fix/71-fix-runner"),
+		gitCommand("checkout", "main"),
+		gitCommand("checkout", "issue-fix/71-fix-runner"),
+		gitCommand("fetch", "origin", "main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("rebase", "origin/main"),
+		gitCommand("rev-parse", "HEAD"),
+	}
+	if !reflect.DeepEqual(shell.cmds, wantCommands) {
+		t.Fatalf("shell commands = %#v, want %#v", shell.cmds, wantCommands)
+	}
+	if strings.Contains(out.String(), "Conflict recovery push result") {
+		t.Fatalf("stdout = %q, want no push summary", out.String())
+	}
+}
+
+func TestRunIssueConflictRecoveryOnlyBlocksWhenDeterministicBranchMissing(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 1},
+		{ExitCode: 2},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+	}
+	agent := &fakeIssueAgentRunner{}
+	var errOut strings.Builder
+	app := NewApp(&strings.Builder{}, &errOut)
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--conflict-recovery-only"})
+	if code != 1 {
+		t.Fatalf("Run() code = %d, want 1", code)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 0 {
+		t.Fatalf("agent call count = %d, want 0", agent.callCount)
+	}
+	if len(lifecycle.commentBodies[71]) != 1 {
+		t.Fatalf("comment bodies = %d, want 1", len(lifecycle.commentBodies[71]))
+	}
+	state, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][0])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody() error = %v", err)
+	}
+	if state.Status != orchestration.StatusBlocked || state.Stage != "sync_branch" || state.NextAction != "run_normal_issue_flow_first" {
+		t.Fatalf("state = %#v", state)
+	}
+	if !strings.Contains(state.Error, "requires an existing deterministic issue branch") {
+		t.Fatalf("blocked error = %q, want missing-branch guidance", state.Error)
+	}
+	wantCommands := []string{
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("show-ref", "--verify", "--quiet", "refs/heads/issue-fix/71-fix-runner"),
+		gitCommand("ls-remote", "--exit-code", "--heads", "origin", "issue-fix/71-fix-runner"),
+	}
+	if !reflect.DeepEqual(shell.cmds, wantCommands) {
+		t.Fatalf("shell commands = %#v, want %#v", shell.cmds, wantCommands)
+	}
+	if !strings.Contains(errOut.String(), "run the normal issue flow first") {
+		t.Fatalf("stderr = %q, want explicit recovery guidance", errOut.String())
+	}
+}
+
 func TestRunIssueBlocksWhenReusedBranchSyncCannotBeRecovered(t *testing.T) {
 	runner := &recordingRunner{}
 	shell := &fakeShellExecutor{results: []shellExecutionResult{

--- a/internal/cli/issue_native.go
+++ b/internal/cli/issue_native.go
@@ -66,9 +66,6 @@ func nativeIssueFallbackReason(opts nativeIssueOptions) string {
 	if *opts.common.dryRun {
 		return "--dry-run is not supported by the Go-native issue path yet"
 	}
-	if opts.conflictRecoveryOnly {
-		return "--conflict-recovery-only is not supported by the Go-native issue path yet"
-	}
 	if strings.TrimSpace(*opts.common.local) != "" {
 		return "--local-config is not supported by the Go-native issue path yet"
 	}
@@ -101,6 +98,9 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 	if err != nil {
 		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to fetch issue #%d: %v\n", opts.issueID, err)
 		return 1
+	}
+	if opts.conflictRecoveryOnly {
+		return a.runNativeIssueConflictRecovery(ctx, repo, issue, opts, &latestState)
 	}
 	comments, err := a.issueLifecycle.ListIssueComments(ctx, repo, issue.Number)
 	if err != nil {
@@ -793,6 +793,121 @@ func (a *App) gitPushBranch(ctx context.Context, repoRoot, branchName string, fo
 	args = append(args, "origin", branchName)
 	_, err := a.runGit(ctx, repoRoot, args...)
 	return err
+}
+
+func (a *App) runNativeIssueConflictRecovery(
+	ctx context.Context,
+	repo string,
+	issue githublifecycle.Issue,
+	opts nativeIssueOptions,
+	latestState **orchestration.TrackedState,
+) int {
+	cwd := defaultSourceDir(*opts.common.dir)
+	repoRoot, err := a.gitRepoRoot(ctx, cwd)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to resolve repository root: %v\n", err)
+		return 1
+	}
+	if dirty, err := a.gitHasChanges(ctx, repoRoot); err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to inspect worktree status: %v\n", err)
+		return 1
+	} else if dirty {
+		_, _ = fmt.Fprintln(a.err, "orchestrator: git working tree must be clean before native issue execution")
+		return 1
+	}
+	originalBranch, err := a.gitCurrentBranch(ctx, repoRoot)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to resolve current branch: %v\n", err)
+		return 1
+	}
+	baseBranch, _, err := a.resolveIssueBaseBranch(ctx, repo, repoRoot, originalBranch, opts.base)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to resolve base branch: %v\n", err)
+		return 1
+	}
+	branchPrefix := strings.TrimSpace(*opts.common.branch)
+	if branchPrefix == "" {
+		branchPrefix = nativeIssueDefaultBranchPrefix
+	}
+	issueBranch := nativeIssueBranchName(issue, branchPrefix)
+	localBranchExists, err := a.gitLocalBranchExists(ctx, repoRoot, issueBranch)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to inspect local branch %q: %v\n", issueBranch, err)
+		return 1
+	}
+	remoteBranchExists, err := a.gitRemoteBranchExists(ctx, repoRoot, issueBranch)
+	if err != nil {
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to inspect remote branch %q: %v\n", issueBranch, err)
+		return 1
+	}
+
+	runnerName := fallbackString(strings.TrimSpace(*opts.common.runner), nativeIssueDefaultRunner)
+	agentName := fallbackString(strings.TrimSpace(*opts.common.agent), nativeIssueDefaultAgent)
+	modelName := fallbackString(strings.TrimSpace(*opts.common.model), nativeIssueDefaultModel)
+	branchLifecycle := orchestration.BranchLifecycleReused
+	var reusedBranchSync *orchestration.ReusedBranchSyncVerdict
+	postState := func(state orchestration.TrackedState) {
+		copy := state
+		*latestState = &copy
+		if err := a.safePostIssueState(ctx, repo, issue.Number, state); err != nil {
+			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post state for issue #%d: %v\n", issue.Number, err)
+		}
+	}
+	buildState := func(status, stage, nextAction, message string) orchestration.TrackedState {
+		return orchestration.TrackedState{
+			Status:           status,
+			TaskType:         "issue",
+			Issue:            intPtr(issue.Number),
+			Branch:           issueBranch,
+			BranchLifecycle:  branchLifecycle,
+			BaseBranch:       baseBranch,
+			Runner:           runnerName,
+			Agent:            agentName,
+			Model:            modelName,
+			Attempt:          1,
+			Stage:            stage,
+			NextAction:       nextAction,
+			Error:            message,
+			Timestamp:        time.Now().UTC().Format(time.RFC3339),
+			ReusedBranchSync: reusedBranchSync,
+		}
+	}
+
+	if !localBranchExists && !remoteBranchExists {
+		message := fmt.Sprintf(
+			"conflict recovery only requires an existing deterministic issue branch, but %q was not found locally or on origin; run the normal issue flow first",
+			issueBranch,
+		)
+		postState(buildState(orchestration.StatusBlocked, "sync_branch", "run_normal_issue_flow_first", message))
+		_, _ = fmt.Fprintf(a.err, "orchestrator: %s\n", message)
+		return 1
+	}
+
+	_, reusedBranchSync, pushWithLease, err := a.prepareIssueBranchPreflight(ctx, repoRoot, baseBranch, issueBranch, localBranchExists, remoteBranchExists, true, opts.syncStrategy)
+	if err != nil {
+		postState(buildState(orchestration.StatusBlocked, "sync_branch", "resolve_branch_sync_conflict", err.Error()))
+		_, _ = fmt.Fprintf(a.err, "orchestrator: failed to recover issue branch %q: %v\n", issueBranch, err)
+		return 1
+	}
+	if reusedBranchSync == nil {
+		message := fmt.Sprintf("conflict recovery for issue branch %q did not produce a sync verdict", issueBranch)
+		postState(buildState(orchestration.StatusFailed, "sync_branch", "inspect_recovery_result", message))
+		_, _ = fmt.Fprintf(a.err, "orchestrator: %s\n", message)
+		return 1
+	}
+
+	if reusedBranchSync.Changed {
+		if err := a.gitPushBranch(ctx, repoRoot, issueBranch, pushWithLease); err != nil {
+			postState(buildState(orchestration.StatusFailed, "sync_branch", "inspect_push_failure", err.Error()))
+			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push recovered issue branch %q: %v\n", issueBranch, err)
+			return 1
+		}
+		_, _ = fmt.Fprintln(a.out, reusedBranchSync.PushSummary(false))
+	}
+
+	postState(buildState(orchestration.StatusWaitingForAuthor, "sync_branch", "inspect_conflict_recovery_result", ""))
+	_, _ = fmt.Fprintln(a.out, reusedBranchSync.Summary(false))
+	return 0
 }
 
 func (a *App) assertNativeGitContext(ctx context.Context, repoRoot, branchName, operation string) error {


### PR DESCRIPTION
## Summary
- Adds Go-native `run issue --conflict-recovery-only` handling for existing deterministic issue branches.
- Reuses Go branch sync helpers, skips agent/PR work, and pushes only sync-only branch updates when needed.
- Posts terminal orchestration state with branch lifecycle and reused-branch sync verdict.

## Verification
- `go test ./...`
- `python3 -m unittest discover -s tests -q`

Part of #243.
Closes #286