### PR TITLE
Ignore local orchestrator artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 .opencode/local-config.json
 opencode.jsonc
 local-config.json
+.orchestrator/
+analysis_report.html


### PR DESCRIPTION
## Summary
- Ignore local `.orchestrator/` worker state and `analysis_report.html` artifacts.
- Keep runtime/generated files from blocking clean-tree checks for orchestrator workers.