### PR TITLE
Fix issue #290: Go migration: move reused-branch and issue conflict-recovery runtime to Go

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1394,7 +1394,7 @@ func TestRunIssueBlocksWhenReusedBranchSyncCannotBeRecovered(t *testing.T) {
 	}
 }
 
-func TestRunIssueRoutesLinkedPRToPRCompatibilityAdapter(t *testing.T) {
+func TestRunIssueRoutesLinkedPRToPRReviewFlow(t *testing.T) {
 	runner := &recordingRunner{}
 	lifecycle := &fakeDaemonLifecycle{
 		issue:    githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
@@ -1404,18 +1404,19 @@ func TestRunIssueRoutesLinkedPRToPRCompatibilityAdapter(t *testing.T) {
 	app := NewApp(&strings.Builder{}, &errOut)
 	app.SetRunner(runner)
 	app.SetIssueLifecycle(lifecycle)
+	app.SetPRLifecycle(nil)
 
 	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo"})
 	if code != 0 {
 		t.Fatalf("Run() code = %d, want 0", code)
 	}
 	assertCommand(t, runner, []string{runnerScript, "--pr", "101", "--from-review-comments", "--repo", "owner/repo"})
-	if !strings.Contains(errOut.String(), "routing issue #71 to pr review compatibility adapter") || !strings.Contains(errOut.String(), "linked open PR #101") {
-		t.Fatalf("stderr = %q, want explicit adapter routing reason", errOut.String())
+	if !strings.Contains(errOut.String(), "routing issue #71 to pr review flow") || !strings.Contains(errOut.String(), "linked open PR #101") {
+		t.Fatalf("stderr = %q, want explicit routing reason", errOut.String())
 	}
 }
 
-func TestRunIssueRoutesReadyToMergeRecoveryToPRCompatibilityAdapter(t *testing.T) {
+func TestRunIssueRoutesReadyToMergeRecoveryToPRReviewFlow(t *testing.T) {
 	runner := &recordingRunner{}
 	stateBody, err := orchestration.BuildOrchestrationStateComment(orchestration.TrackedState{
 		Status:   orchestration.StatusReadyToMerge,
@@ -1437,6 +1438,7 @@ func TestRunIssueRoutesReadyToMergeRecoveryToPRCompatibilityAdapter(t *testing.T
 	app := NewApp(&strings.Builder{}, &errOut)
 	app.SetRunner(runner)
 	app.SetIssueLifecycle(lifecycle)
+	app.SetPRLifecycle(nil)
 
 	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo"})
 	if code != 0 {

--- a/internal/cli/issue_native.go
+++ b/internal/cli/issue_native.go
@@ -129,7 +129,13 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 	}
 	if decision.Mode != orchestration.ExecutionModeIssueFlow {
 		if decision.Mode == orchestration.ExecutionModePRReview && linkedPR != nil {
-			_, _ = fmt.Fprintf(a.err, "orchestrator: routing issue #%d to pr review compatibility adapter: %s\n", issue.Number, decision.Reason)
+			_, _ = fmt.Fprintf(a.err, "orchestrator: routing issue #%d to pr review flow: %s\n", issue.Number, decision.Reason)
+			if code, ok := a.tryRunNativePR(ctx, nativePROptions{
+				prID:   linkedPR.Number,
+				common: opts.common,
+			}); ok {
+				return code
+			}
 			return a.runPython(ctx, buildPRPythonArgs(
 				a.runtime.RunnerScript(),
 				opts.common,


### PR DESCRIPTION
## Summary
- Implements fix for #290
- Source issue: https://github.com/podlodka-ai-club/steam-hammer/issues/290

Closes #290
