### PR TITLE
Go migration: run daemon PR-review tasks in isolated worktrees by default

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1577,6 +1577,13 @@ func TestRunBatchDetachRoutesLinkedPRToNativePRCommand(t *testing.T) {
 	if !reflect.DeepEqual(starter.req.Args[:4], []string{"run", "pr", "--id", "101"}) {
 		t.Fatalf("worker args = %#v, want native pr entrypoint", starter.req.Args)
 	}
+	joined := strings.Join(starter.req.Args, " ")
+	if !strings.Contains(joined, "--isolate-worktree") {
+		t.Fatalf("worker args = %#v, want isolate worktree flag", starter.req.Args)
+	}
+	if strings.Contains(joined, "--allow-pr-branch-switch") {
+		t.Fatalf("worker args = %#v, should not include branch switch flag", starter.req.Args)
+	}
 }
 
 func TestRunBatchDetachFallsBackToPythonWhenNativeIssueUnsupported(t *testing.T) {
@@ -1715,7 +1722,7 @@ func TestRunDaemonCommandWiresPythonRunner(t *testing.T) {
 	assertCommandContainsFlag(t, runner.args, "--autonomous-session-file")
 }
 
-func TestRunDaemonRoutesLinkedPRWorkerWithSafeBranchSwitch(t *testing.T) {
+func TestRunDaemonRoutesLinkedPRWorkerWithIsolatedWorktree(t *testing.T) {
 	runner := &recordingRunner{}
 	app := NewApp(&strings.Builder{}, &strings.Builder{})
 	app.SetRunner(runner)
@@ -1737,8 +1744,11 @@ func TestRunDaemonRoutesLinkedPRWorkerWithSafeBranchSwitch(t *testing.T) {
 	if !strings.Contains(joined, "--pr") || !strings.Contains(joined, "101") {
 		t.Fatalf("runner args = %#v, want PR routing", runner.args)
 	}
-	if !strings.Contains(joined, "--allow-pr-branch-switch") {
-		t.Fatalf("runner args = %#v, want safe branch switch flag", runner.args)
+	if !strings.Contains(joined, "--isolate-worktree") {
+		t.Fatalf("runner args = %#v, want isolate worktree flag", runner.args)
+	}
+	if strings.Contains(joined, "--allow-pr-branch-switch") {
+		t.Fatalf("runner args = %#v, should not include branch switch flag", runner.args)
 	}
 }
 

--- a/internal/cli/command_run.go
+++ b/internal/cli/command_run.go
@@ -506,7 +506,7 @@ func (a *App) buildBatchWorkerLaunchCommand(ctx context.Context, opts commonOpti
 	if decision.Mode == orchestration.ExecutionModePRReview && linkedPR != nil {
 		pythonPR := workerLaunchCommand{
 			name: "python3",
-			args: buildPRPythonArgs(a.runtime.RunnerScript(), opts, linkedPR.Number, true, false, false, "", false, ""),
+			args: buildPRPythonArgs(a.runtime.RunnerScript(), opts, linkedPR.Number, false, true, false, "", false, ""),
 		}
 		if reason := nativePRFallbackReason(nativePROptions{prID: linkedPR.Number, common: opts}); reason != "" {
 			pythonPR.fallbackReason = reason
@@ -517,7 +517,7 @@ func (a *App) buildBatchWorkerLaunchCommand(ctx context.Context, opts commonOpti
 			pythonPR.fallbackReason = fmt.Sprintf("failed to resolve orchestrator executable: %v", err)
 			return pythonPR
 		}
-		return workerLaunchCommand{name: execPath, args: buildPRCLIArgs(opts, linkedPR.Number, true, false, false, "", false, "")}
+		return workerLaunchCommand{name: execPath, args: buildPRCLIArgs(opts, linkedPR.Number, false, true, false, "", false, "")}
 	}
 
 	if reason := nativeIssueFallbackReason(nativeIssueOptions{


### PR DESCRIPTION
## Summary
- Implements fix for #312
- Source issue: https://github.com/podlodka-ai-club/steam-hammer/issues/312

Closes #312
