### PR TITLE
Go migration: auto-run conflict recovery after PR-review updates leave PR dirty

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -23,6 +23,7 @@ type recordingRunner struct {
 	args  []string
 	calls int
 	cmds  [][]string
+	err   error
 }
 
 func (r *recordingRunner) Run(_ context.Context, name string, args ...string) error {
@@ -32,7 +33,7 @@ func (r *recordingRunner) Run(_ context.Context, name string, args ...string) er
 	r.args = append([]string(nil), args...)
 	r.calls++
 	r.cmds = append(r.cmds, append([]string{name}, args...))
-	return nil
+	return r.err
 }
 
 type failingRunner struct {
@@ -312,7 +313,7 @@ func TestHelpDoesNotInvokeRunner(t *testing.T) {
 }
 
 func TestDoctorCommandRunsGoNativeChecks(t *testing.T) {
-	runner := &recordingRunner{}
+	runner := &recordingRunner{err: os.ErrNotExist}
 	var out strings.Builder
 	app := NewApp(&out, &strings.Builder{})
 	app.SetRunner(runner)
@@ -330,7 +331,7 @@ func TestDoctorCommandRunsGoNativeChecks(t *testing.T) {
 }
 
 func TestAutoDoctorCommandIncludesNextStepGuidance(t *testing.T) {
-	runner := &recordingRunner{}
+	runner := &recordingRunner{err: os.ErrNotExist}
 	var out strings.Builder
 	app := NewApp(&out, &strings.Builder{})
 	app.SetRunner(runner)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1876,7 +1876,7 @@ func TestRunDaemonRoutesLinkedPRWorkerWithIsolatedWorktree(t *testing.T) {
 		t.Fatalf("runner calls = %d, want 1", runner.calls)
 	}
 	joined := strings.Join(runner.args, "\n")
-	if !strings.Contains(joined, "--pr") || !strings.Contains(joined, "101") {
+	if !strings.Contains(joined, "run\npr") || !strings.Contains(joined, "--id") || !strings.Contains(joined, "101") {
 		t.Fatalf("runner args = %#v, want PR routing", runner.args)
 	}
 	if !strings.Contains(joined, "--isolate-worktree") {
@@ -1884,6 +1884,34 @@ func TestRunDaemonRoutesLinkedPRWorkerWithIsolatedWorktree(t *testing.T) {
 	}
 	if strings.Contains(joined, "--allow-pr-branch-switch") {
 		t.Fatalf("runner args = %#v, should not include branch switch flag", runner.args)
+	}
+}
+
+func TestRunDaemonRoutesDirtyLinkedPRToConflictRecovery(t *testing.T) {
+	runner := &recordingRunner{}
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetIssueLifecycle(&fakeDaemonLifecycle{
+		issue:           githublifecycle.Issue{Number: 71, Title: "Fix runtime", Body: "Body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		linkedPR:        &githublifecycle.PullRequest{Number: 101, Title: "Existing fix", HeadRefName: "feature/pr-101", BaseRefName: "main", MergeStateStatus: "DIRTY", Mergeable: "CONFLICTING"},
+		commentsByIssue: map[int][]githublifecycle.IssueComment{},
+	})
+	app.SetDaemonLifecycle(&fakeDaemonLifecycle{
+		issues:          []githublifecycle.Issue{{Number: 71}},
+		linkedPR:        &githublifecycle.PullRequest{Number: 101, Title: "Existing fix", HeadRefName: "feature/pr-101", BaseRefName: "main", MergeStateStatus: "DIRTY", Mergeable: "CONFLICTING"},
+		commentsByIssue: map[int][]githublifecycle.IssueComment{},
+	})
+
+	code := app.Run([]string{"run", "daemon", "--repo", "owner/repo", "--limit", "1", "--max-cycles", "1", "--poll-interval-seconds", "0", "--dry-run"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	joined := strings.Join(runner.args, "\n")
+	if !strings.Contains(joined, "run\npr") || !strings.Contains(joined, "--id") || !strings.Contains(joined, "101") || !strings.Contains(joined, "--conflict-recovery-only") {
+		t.Fatalf("runner args = %#v, want PR conflict recovery routing", runner.args)
+	}
+	if strings.Contains(joined, "--isolate-worktree") {
+		t.Fatalf("runner args = %#v, conflict recovery should use native PR branch sync", runner.args)
 	}
 }
 
@@ -2330,6 +2358,130 @@ func TestRunPRUsesNativeRuntimeLoopWhenRepoExplicit(t *testing.T) {
 	}
 	if !strings.Contains(joinedShell, "git 'push' '-u' 'origin' 'feature/pr-72'") {
 		t.Fatalf("shell commands missing PR push: %s", joinedShell)
+	}
+}
+
+func TestRunPRNativeRunsConflictRecoveryWhenReviewUpdateLeavesPRDirty(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: ""},
+		{Stdout: " M internal/cli/pr_native.go\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: ""},
+		{Stdout: "[feature/pr-72 abc123] Address review comments for PR #72\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: "pushed\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{ExitCode: 0},
+		{ExitCode: 0},
+		{},
+		{},
+		{},
+		{Stdout: "abc123\n"},
+		{},
+		{Stdout: "def456\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{},
+	}}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{ExitCode: 0}}
+	lifecycle := &fakeDaemonLifecycle{
+		pullRequests: []githublifecycle.PullRequest{
+			{Number: 72, Title: "Fix review feedback", URL: "https://github.com/owner/repo/pull/72", HeadRefName: "feature/pr-72", BaseRefName: "main", Author: &githublifecycle.Actor{Login: "author"}},
+			{Number: 72, Title: "Fix review feedback", URL: "https://github.com/owner/repo/pull/72", HeadRefName: "feature/pr-72", BaseRefName: "main", MergeStateStatus: "DIRTY", Mergeable: "CONFLICTING", Author: &githublifecycle.Actor{Login: "author"}},
+		},
+		reviewThreadSeq: [][]githublifecycle.PullRequestReviewThread{{{
+			Comments: []githublifecycle.PullRequestReviewComment{{Body: "Please add a regression test", Path: "internal/cli/pr_native.go", Line: 12, Author: &githublifecycle.Actor{Login: "reviewer"}}},
+		}}},
+	}
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueAgentRunner(agent)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetPRLifecycle(lifecycle)
+
+	code := app.Run([]string{"run", "pr", "--id", "72", "--repo", "owner/repo", "--dir", "/repo"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if agent.callCount != 1 {
+		t.Fatalf("agent call count = %d, want 1", agent.callCount)
+	}
+	lastComment := lifecycle.prCommentBodies[72][len(lifecycle.prCommentBodies[72])-1]
+	state, err := orchestration.ParseOrchestrationStateCommentBody(lastComment)
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody() error = %v", err)
+	}
+	if state == nil || state.Stage != "sync_branch" || state.ReusedBranchSync == nil || state.ReusedBranchSync.Status != orchestration.BranchSyncStatusSyncedCleanly {
+		t.Fatalf("final PR state = %#v, want conflict recovery sync state", state)
+	}
+}
+
+func TestRunPRNativeRebasesAndRetriesRejectedPush(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: ""},
+		{Stdout: " M internal/cli/pr_native.go\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: ""},
+		{Stdout: "[feature/pr-72 abc123] Address review comments for PR #72\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{ExitCode: 1, Stderr: "! [rejected] feature/pr-72 -> feature/pr-72 (fetch first)\nerror: failed to push some refs\n"},
+		{Stdout: "abc123\n"},
+		{},
+		{},
+		{Stdout: "def456\n"},
+		{Stdout: "feature/pr-72\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: "pushed\n"},
+	}}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{ExitCode: 0}}
+	lifecycle := &fakeDaemonLifecycle{
+		pullRequests: []githublifecycle.PullRequest{
+			{Number: 72, Title: "Fix review feedback", URL: "https://github.com/owner/repo/pull/72", HeadRefName: "feature/pr-72", BaseRefName: "main", Author: &githublifecycle.Actor{Login: "author"}},
+			{Number: 72, Title: "Fix review feedback", URL: "https://github.com/owner/repo/pull/72", HeadRefName: "feature/pr-72", BaseRefName: "main", MergeStateStatus: "CLEAN", Mergeable: "MERGEABLE", Author: &githublifecycle.Actor{Login: "author"}},
+		},
+		reviewThreadSeq: [][]githublifecycle.PullRequestReviewThread{
+			{{Comments: []githublifecycle.PullRequestReviewComment{{Body: "Please add a regression test", Path: "internal/cli/pr_native.go", Line: 12, Author: &githublifecycle.Actor{Login: "reviewer"}}}}},
+			{},
+		},
+	}
+	app := NewApp(&strings.Builder{}, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueAgentRunner(agent)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetPRLifecycle(lifecycle)
+
+	code := app.Run([]string{"run", "pr", "--id", "72", "--repo", "owner/repo", "--dir", "/repo"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	joinedShell := strings.Join(shell.cmds, "\n")
+	if !strings.Contains(joinedShell, "git 'fetch' 'origin' 'feature/pr-72'") || !strings.Contains(joinedShell, "git 'rebase' 'origin/feature/pr-72'") {
+		t.Fatalf("shell commands missing rejected-push rebase recovery: %s", joinedShell)
+	}
+	lastComment := lifecycle.prCommentBodies[72][len(lifecycle.prCommentBodies[72])-1]
+	state, err := orchestration.ParseOrchestrationStateCommentBody(lastComment)
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody() error = %v", err)
+	}
+	if state == nil || state.ReusedBranchSync == nil || state.ReusedBranchSync.RemoteBaseRef != "origin/feature/pr-72" {
+		t.Fatalf("final PR state = %#v, want push rejection rebase verdict", state)
 	}
 }
 

--- a/internal/cli/command_run.go
+++ b/internal/cli/command_run.go
@@ -501,6 +501,22 @@ func (a *App) buildBatchWorkerLaunchCommand(ctx context.Context, opts commonOpti
 		pythonIssue.fallbackReason = fmt.Sprintf("failed to inspect linked PR for issue #%d: %v", id, err)
 		return pythonIssue
 	}
+	if linkedPR != nil && prNeedsConflictRecovery(*linkedPR) {
+		pythonPR := workerLaunchCommand{
+			name: "python3",
+			args: buildPRPythonArgs(a.runtime.RunnerScript(), opts, linkedPR.Number, false, true, false, "", true, syncStrategy),
+		}
+		if reason := nativePRFallbackReason(nativePROptions{prID: linkedPR.Number, common: opts, conflictRecoveryOnly: true, syncStrategy: syncStrategy}); reason != "" {
+			pythonPR.fallbackReason = reason
+			return pythonPR
+		}
+		execPath, err := a.currentExecutable()
+		if err != nil {
+			pythonPR.fallbackReason = fmt.Sprintf("failed to resolve orchestrator executable: %v", err)
+			return pythonPR
+		}
+		return workerLaunchCommand{name: execPath, args: buildPRCLIArgs(opts, linkedPR.Number, false, false, false, "", true, syncStrategy)}
+	}
 	decision := orchestration.ChooseExecutionMode(id, linkedPRNumber(linkedPR), forceIssueFlow, parsedStatePayload(recoveredState), nil)
 
 	if decision.Mode == orchestration.ExecutionModePRReview && linkedPR != nil {
@@ -586,10 +602,17 @@ func (a *App) selectDaemonIssues(ctx context.Context, config daemonParallelConfi
 			ForceReprocess:       config.forceReprocess,
 			LastHandledSignature: handled.signatures[issue.Number],
 		}
-		if reviewSignal, err := a.daemonReviewFeedbackSignal(ctx, strings.TrimSpace(*config.opts.repo), issue); err != nil {
+		if conflictSignal, err := a.daemonPRConflictRecoverySignal(ctx, strings.TrimSpace(*config.opts.repo), issue); err != nil {
 			return nil, err
 		} else {
-			snapshot.ReviewFeedbackSignal = reviewSignal
+			snapshot.PRConflictSignal = conflictSignal
+		}
+		if snapshot.PRConflictSignal == "" {
+			if reviewSignal, err := a.daemonReviewFeedbackSignal(ctx, strings.TrimSpace(*config.opts.repo), issue); err != nil {
+				return nil, err
+			} else {
+				snapshot.ReviewFeedbackSignal = reviewSignal
+			}
 		}
 		if latestState != nil {
 			snapshot.LatestStateStatus = latestState.Status
@@ -613,6 +636,19 @@ func (a *App) selectDaemonIssues(ctx context.Context, config daemonParallelConfi
 		seen[issue.Number] = struct{}{}
 	}
 	return selected, nil
+}
+
+func (a *App) daemonPRConflictRecoverySignal(ctx context.Context, repo string, issue corelifecycle.Issue) (string, error) {
+	linkedPR, err := a.daemon.FindOpenPullRequestForIssue(ctx, repo, issue)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect linked PR for issue #%d: %w", issue.Number, err)
+	}
+	if linkedPR == nil || !prNeedsConflictRecovery(*linkedPR) {
+		return "", nil
+	}
+	mergeState := strings.TrimSpace(strings.ToUpper(linkedPR.MergeStateStatus))
+	mergeable := strings.TrimSpace(strings.ToUpper(linkedPR.Mergeable))
+	return fmt.Sprintf("pr-%d:%s:%s", linkedPR.Number, mergeState, mergeable), nil
 }
 
 func (a *App) daemonReviewFeedbackSignal(ctx context.Context, repo string, issue corelifecycle.Issue) (string, error) {
@@ -915,10 +951,10 @@ func (a *App) runParallelDaemon(ctx context.Context, config daemonParallelConfig
 			cancel()
 			if releaseClaimsAfterCycle {
 				if err := a.releaseDaemonClaims(ctx, config, selected); err != nil {
-				_, _ = fmt.Fprintf(a.err, "orchestrator: failed to release daemon claims: %v\n", err)
-				if cycleCode == 0 {
-					cycleCode = 1
-				}
+					_, _ = fmt.Fprintf(a.err, "orchestrator: failed to release daemon claims: %v\n", err)
+					if cycleCode == 0 {
+						cycleCode = 1
+					}
 				}
 			}
 		}
@@ -1007,10 +1043,10 @@ func (a *App) runSerialDaemon(ctx context.Context, config daemonParallelConfig) 
 			}
 			if releaseClaimsAfterCycle {
 				if err := a.releaseDaemonClaims(ctx, config, selected); err != nil {
-				_, _ = fmt.Fprintf(a.err, "orchestrator: failed to release daemon claims: %v\n", err)
-				if cycleCode == 0 {
-					cycleCode = 1
-				}
+					_, _ = fmt.Fprintf(a.err, "orchestrator: failed to release daemon claims: %v\n", err)
+					if cycleCode == 0 {
+						cycleCode = 1
+					}
 				}
 			}
 			if cycleCode == 0 && config.postBatchVerify {

--- a/internal/cli/pr_native.go
+++ b/internal/cli/pr_native.go
@@ -334,27 +334,45 @@ func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions
 			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to commit PR changes: %v\n", err)
 			return 1
 		}
+		var pushRebase *orchestration.ReusedBranchSyncVerdict
 		if err := a.gitPushBranch(ctx, repoRoot, activeBranch, false); err != nil {
-			postState(failedState(attempt, "commit_push", "inspect_push_failure", err.Error(), reviewOutcome))
-			_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push PR branch %q: %v\n", activeBranch, err)
-			return 1
+			if isGitPushRejected(err) {
+				verdict, retryErr := a.rebasePRBranchAfterPushRejection(ctx, repoRoot, activeBranch)
+				if retryErr == nil {
+					pushRebase = &verdict
+					_, _ = fmt.Fprintln(a.out, verdict.Summary(false))
+					retryErr = a.gitPushBranch(ctx, repoRoot, activeBranch, false)
+				}
+				if retryErr == nil {
+					_, _ = fmt.Fprintf(a.out, "Retried PR branch push after rebasing on origin/%s.\n", activeBranch)
+				} else {
+					postState(failedState(attempt, "commit_push", "resolve_branch_sync_conflict", retryErr.Error(), reviewOutcome))
+					_, _ = fmt.Fprintf(a.err, "orchestrator: failed to recover rejected push for PR branch %q: %v\n", activeBranch, retryErr)
+					return 1
+				}
+			} else {
+				postState(failedState(attempt, "commit_push", "inspect_push_failure", err.Error(), reviewOutcome))
+				_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push PR branch %q: %v\n", activeBranch, err)
+				return 1
+			}
 		}
 
 		postState(orchestration.TrackedState{
-			Status:         orchestration.StatusWaitingForCI,
-			TaskType:       "pr",
-			PR:             intPtr(pullRequest.Number),
-			Branch:         activeBranch,
-			BaseBranch:     strings.TrimSpace(pullRequest.BaseRefName),
-			Runner:         runnerName,
-			Agent:          agentName,
-			Model:          modelName,
-			Attempt:        attempt,
-			Stage:          "pr_update",
-			NextAction:     "wait_for_ci",
-			Timestamp:      time.Now().UTC().Format(time.RFC3339),
-			Stats:          statsMap(result.Stats),
-			ReviewFeedback: reviewOutcome,
+			Status:           orchestration.StatusWaitingForCI,
+			TaskType:         "pr",
+			PR:               intPtr(pullRequest.Number),
+			Branch:           activeBranch,
+			BaseBranch:       strings.TrimSpace(pullRequest.BaseRefName),
+			Runner:           runnerName,
+			Agent:            agentName,
+			Model:            modelName,
+			Attempt:          attempt,
+			Stage:            "pr_update",
+			NextAction:       "wait_for_ci",
+			Timestamp:        time.Now().UTC().Format(time.RFC3339),
+			Stats:            statsMap(result.Stats),
+			ReviewFeedback:   reviewOutcome,
+			ReusedBranchSync: pushRebase,
 		})
 
 		updatedPR, err := a.prLifecycle.FetchPullRequest(ctx, repo, pullRequest.Number)
@@ -364,6 +382,10 @@ func (a *App) runNativePR(ctx context.Context, repo string, opts nativePROptions
 			return 1
 		}
 		pullRequest = updatedPR
+		if prNeedsConflictRecovery(pullRequest) {
+			_, _ = fmt.Fprintf(a.out, "PR #%d is %s/%s after review update; running conflict recovery before more review feedback.\n", pullRequest.Number, strings.TrimSpace(pullRequest.MergeStateStatus), strings.TrimSpace(pullRequest.Mergeable))
+			return a.runNativePRConflictRecovery(ctx, repo, pullRequest, opts, &latestState)
+		}
 		remainingItems, remainingStats, err := a.fetchNativePRReviewFeedback(ctx, repo, pullRequest)
 		if err != nil {
 			postState(failedState(attempt, "review_feedback", "inspect_review_feedback", err.Error(), reviewOutcome))
@@ -743,6 +765,49 @@ func appendRemainingReviewOutcomes(existing *orchestration.PRReviewOutcomeSummar
 		})
 	}
 	return &orchestration.PRReviewOutcomeSummary{Items: items}
+}
+
+func prNeedsConflictRecovery(pullRequest lifecycle.PullRequest) bool {
+	return orchestration.ClassifyPRMergeReadinessState(pullRequest.MergeStateStatus, pullRequest.Mergeable) == orchestration.MergeReadinessConflicting
+}
+
+func isGitPushRejected(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "fetch first") ||
+		strings.Contains(message, "non-fast-forward") ||
+		(strings.Contains(message, "failed to push some refs") && strings.Contains(message, "rejected"))
+}
+
+func (a *App) rebasePRBranchAfterPushRejection(ctx context.Context, repoRoot, branchName string) (orchestration.ReusedBranchSyncVerdict, error) {
+	remoteBranchRef := "origin/" + strings.TrimSpace(branchName)
+	beforeSyncSHA, err := a.gitCurrentHeadSHA(ctx, repoRoot)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	if _, err := a.runGit(ctx, repoRoot, "fetch", "origin", branchName); err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	if _, err := a.runGit(ctx, repoRoot, "rebase", remoteBranchRef); err != nil {
+		_, _ = a.gitCommandSucceeds(ctx, repoRoot, "rebase", "--abort")
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	afterSyncSHA, err := a.gitCurrentHeadSHA(ctx, repoRoot)
+	if err != nil {
+		return orchestration.ReusedBranchSyncVerdict{}, err
+	}
+	changed := beforeSyncSHA != afterSyncSHA
+	return orchestration.ReusedBranchSyncVerdict{
+		BranchName:        branchName,
+		RemoteBaseRef:     remoteBranchRef,
+		RequestedStrategy: "rebase",
+		AppliedStrategy:   "rebase",
+		Status:            branchSyncStatus(changed, false),
+		Changed:           changed,
+		AutoResolved:      false,
+	}, nil
 }
 
 func nativePRCommitTitle(pullRequest lifecycle.PullRequest) string {

--- a/internal/core/orchestration/daemon_policy.go
+++ b/internal/core/orchestration/daemon_policy.go
@@ -16,6 +16,7 @@ type DaemonTaskSnapshot struct {
 	IssueNumber          int
 	RunID                string
 	ForceReprocess       bool
+	PRConflictSignal     string
 	ReviewFeedbackSignal string
 	LatestStateStatus    string
 	LatestStateTaskType  string
@@ -133,6 +134,10 @@ func decodeProcessedTrackedState(raw json.RawMessage) (TrackedState, bool) {
 }
 
 func daemonTaskSignature(snapshot DaemonTaskSnapshot) string {
+	conflictSignal := strings.TrimSpace(snapshot.PRConflictSignal)
+	if conflictSignal != "" {
+		return "conflict-recovery:" + conflictSignal
+	}
 	reviewSignal := strings.TrimSpace(snapshot.ReviewFeedbackSignal)
 	if reviewSignal != "" {
 		return "review:" + reviewSignal

--- a/internal/core/orchestration/daemon_policy_test.go
+++ b/internal/core/orchestration/daemon_policy_test.go
@@ -81,16 +81,33 @@ func TestEvaluateDaemonTaskSelectionSkipsAlreadyHandledSignature(t *testing.T) {
 
 func TestEvaluateDaemonTaskSelectionPrefersReviewFeedbackSignal(t *testing.T) {
 	decision := EvaluateDaemonTaskSelection(DaemonTaskSnapshot{
-		IssueNumber:           249,
-		LatestStateStatus:     StatusReadyForReview,
-		ReviewFeedbackSignal:  "pr-101:actionable",
-		LastHandledSignature:  "state:ready-for-review",
+		IssueNumber:          249,
+		LatestStateStatus:    StatusReadyForReview,
+		ReviewFeedbackSignal: "pr-101:actionable",
+		LastHandledSignature: "state:ready-for-review",
 	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 
 	if !decision.Eligible {
 		t.Fatalf("Eligible = false, want true (%q)", decision.Reason)
 	}
 	if decision.Signature != "review:pr-101:actionable" {
+		t.Fatalf("Signature = %q", decision.Signature)
+	}
+}
+
+func TestEvaluateDaemonTaskSelectionPrefersConflictRecoverySignal(t *testing.T) {
+	decision := EvaluateDaemonTaskSelection(DaemonTaskSnapshot{
+		IssueNumber:          249,
+		LatestStateStatus:    StatusReadyForReview,
+		PRConflictSignal:     "pr-101:DIRTY:CONFLICTING",
+		ReviewFeedbackSignal: "pr-101:actionable",
+		LastHandledSignature: "review:pr-101:actionable",
+	}, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+
+	if !decision.Eligible {
+		t.Fatalf("Eligible = false, want true (%q)", decision.Reason)
+	}
+	if decision.Signature != "conflict-recovery:pr-101:DIRTY:CONFLICTING" {
 		t.Fatalf("Signature = %q", decision.Signature)
 	}
 }


### PR DESCRIPTION
## Summary
- Implements fix for #315
- Source issue: https://github.com/podlodka-ai-club/steam-hammer/issues/315

Closes #315
