### PR TITLE
Go migration: stabilize date-sensitive autonomous tests

### DIFF
--- a/internal/core/orchestration/daemon_policy_test.go
+++ b/internal/core/orchestration/daemon_policy_test.go
@@ -64,6 +64,26 @@ func TestEvaluateDaemonTaskSelectionSkipsActiveForeignClaim(t *testing.T) {
 	}
 }
 
+func TestEvaluateDaemonTaskSelectionUsesFixedNowForExpiredForeignClaim(t *testing.T) {
+	decision := EvaluateDaemonTaskSelection(DaemonTaskSnapshot{
+		IssueNumber:       249,
+		RunID:             "run-2",
+		LatestStateStatus: StatusReadyForReview,
+		LatestClaim: map[string]any{
+			"status":     "claimed",
+			"run_id":     "run-1",
+			"expires_at": "2026-05-01T12:05:00Z",
+		},
+	}, time.Date(2026, 5, 1, 12, 6, 0, 0, time.UTC))
+
+	if !decision.Eligible {
+		t.Fatalf("Eligible = false, want true (%q)", decision.Reason)
+	}
+	if decision.Signature != "state:ready-for-review" {
+		t.Fatalf("Signature = %q", decision.Signature)
+	}
+}
+
 func TestEvaluateDaemonTaskSelectionSkipsAlreadyHandledSignature(t *testing.T) {
 	decision := EvaluateDaemonTaskSelection(DaemonTaskSnapshot{
 		IssueNumber:          249,

--- a/scripts/run_github_issues_to_opencode.py
+++ b/scripts/run_github_issues_to_opencode.py
@@ -790,7 +790,7 @@ def project_scope_defaults(project_config: dict) -> dict:
     return defaults
 
 
-def evaluate_issue_scope(issue: dict, scope_defaults: dict) -> dict:
+def evaluate_issue_scope(issue: dict, scope_defaults: dict, now: datetime | None = None) -> dict:
     labels_config = scope_defaults.get("labels") if isinstance(scope_defaults, dict) else None
     authors_config = scope_defaults.get("authors") if isinstance(scope_defaults, dict) else None
     assignees_config = scope_defaults.get("assignees") if isinstance(scope_defaults, dict) else None
@@ -916,7 +916,12 @@ def evaluate_issue_scope(issue: dict, scope_defaults: dict) -> dict:
                 "matched": {"priority_allow": []},
             }
 
-    now = datetime.now(timezone.utc)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
     created_at = _parse_iso_timestamp(issue.get("createdAt"))
     updated_at = _parse_iso_timestamp(issue.get("updatedAt"))
     if isinstance(max_age_days, int) and max_age_days > 0 and created_at is not None:

--- a/tests/test_autonomous_daemon_selection.py
+++ b/tests/test_autonomous_daemon_selection.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import datetime, timezone
 import io
 import json
 import os
@@ -187,6 +188,7 @@ class AutonomousDaemonSelectionTests(unittest.TestCase):
                 "priority": {"allow": ["priority:high"], "order": ["priority:high", "priority:low"]},
                 "freshness": {"max_age_days": 7, "max_idle_days": 7},
             },
+            now=datetime(2026, 4, 28, 10, 0, tzinfo=timezone.utc),
         )
 
         self.assertTrue(decision["eligible"])
@@ -201,10 +203,26 @@ class AutonomousDaemonSelectionTests(unittest.TestCase):
         decision = evaluate_issue_scope(
             issue=issue,
             scope_defaults={"freshness": {"max_idle_days": 1}},
+            now=datetime(2026, 4, 28, 10, 0, tzinfo=timezone.utc),
         )
 
         self.assertFalse(decision["eligible"])
         self.assertIn("too stale", decision["reason"])
+
+    def test_scope_evaluation_uses_supplied_fixed_time_for_freshness(self) -> None:
+        issue = {
+            "number": 94,
+            "createdAt": "2026-04-26T10:00:00Z",
+            "updatedAt": "2026-04-27T10:00:00Z",
+        }
+
+        decision = evaluate_issue_scope(
+            issue=issue,
+            scope_defaults={"freshness": {"max_age_days": 7, "max_idle_days": 7}},
+            now=datetime(2026, 4, 28, 10, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertTrue(decision["eligible"])
 
     def test_sort_autonomous_issues_prefers_priority_then_freshness(self) -> None:
         issues = [


### PR DESCRIPTION
## Summary
- Implements fix for #317
- Source issue: https://github.com/podlodka-ai-club/steam-hammer/issues/317

Closes #317
