### PR TITLE
Go migration: implement native conflict-recovery-only runtime

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -320,7 +320,8 @@ func TestHelpDoesNotInvokeRunner(t *testing.T) {
 func TestDoctorCommandRunsGoNativeChecks(t *testing.T) {
 	runner := &recordingRunner{err: os.ErrNotExist}
 	var out strings.Builder
-	app := NewApp(&out, &strings.Builder{})
+	var errOut strings.Builder
+	app := NewApp(&out, &errOut)
 	app.SetRunner(runner)
 
 	code := app.Run([]string{"doctor", "--repo", "owner/repo", "--dry-run"})
@@ -898,6 +899,8 @@ func TestRunIssueUsesGoNativeHappyPath(t *testing.T) {
 		{},
 		{Stdout: "issue-fix/71-fix-runner\n"},
 		{Stdout: "/repo\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
 		{},
 	}}
 	lifecycle := &fakeDaemonLifecycle{
@@ -1160,6 +1163,97 @@ func TestRunIssueUsesGoNativeReusedBranchSyncPreflight(t *testing.T) {
 		gitCommand("add", "-u"),
 		gitCommand("ls-files", "--others", "--exclude-standard"),
 		gitCommand("commit", "-m", "Fix issue #71: Fix runner"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("push", "-u", "--force-with-lease", "origin", "issue-fix/71-fix-runner"),
+	}
+	if !reflect.DeepEqual(shell.cmds, wantCommands) {
+		t.Fatalf("shell commands = %#v, want %#v", shell.cmds, wantCommands)
+	}
+}
+
+func TestRunIssuePushesSyncOnlyUpdateWhenReusedBranchChangedAndAgentNoop(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 0},
+		{ExitCode: 0},
+		{},
+		{},
+		{},
+		{Stdout: "abc123\n"},
+		{},
+		{Stdout: "def456\n"},
+		{Stdout: ""},
+		{Stdout: "\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+		{},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+		createPRURL:   "https://github.com/owner/repo/pull/101",
+	}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{Stats: agentexec.Stats{ElapsedSeconds: 7}}}
+	var out strings.Builder
+	var errOut strings.Builder
+	app := NewApp(&out, &errOut)
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo", "--no-skip-if-branch-exists"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0; stderr=%q cmds=%#v", code, errOut.String(), shell.cmds)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("python runner calls = %d, want 0", runner.calls)
+	}
+	if agent.callCount != 1 {
+		t.Fatalf("agent call count = %d, want 1", agent.callCount)
+	}
+	if len(lifecycle.createdPRs) != 1 {
+		t.Fatalf("created PRs = %d, want 1", len(lifecycle.createdPRs))
+	}
+	if len(lifecycle.commentBodies[71]) != 2 {
+		t.Fatalf("comment bodies = %d, want 2", len(lifecycle.commentBodies[71]))
+	}
+	finalState, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][1])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody(final) error = %v", err)
+	}
+	if finalState.Status != orchestration.StatusReadyForReview || finalState.Stage != "pr_ready" || finalState.NextAction != "wait_for_review" {
+		t.Fatalf("final state = %#v", finalState)
+	}
+	if finalState.ReusedBranchSync == nil || !finalState.ReusedBranchSync.Changed {
+		t.Fatalf("final state sync verdict = %#v, want changed sync verdict", finalState.ReusedBranchSync)
+	}
+	if !strings.Contains(out.String(), "No file changes from agent for issue #71; pushed sync-only branch updates") {
+		t.Fatalf("stdout = %q, want sync-only message", out.String())
+	}
+
+	wantCommands := []string{
+		gitCommand("rev-parse", "--show-toplevel"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("show-ref", "--verify", "--quiet", "refs/heads/issue-fix/71-fix-runner"),
+		gitCommand("ls-remote", "--exit-code", "--heads", "origin", "issue-fix/71-fix-runner"),
+		gitCommand("checkout", "main"),
+		gitCommand("checkout", "issue-fix/71-fix-runner"),
+		gitCommand("fetch", "origin", "main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("rebase", "origin/main"),
+		gitCommand("rev-parse", "HEAD"),
+		gitCommand("ls-files", "--others", "--exclude-standard"),
+		gitCommand("status", "--porcelain"),
+		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
+		gitCommand("rev-parse", "--show-toplevel"),
 		gitCommand("rev-parse", "--abbrev-ref", "HEAD"),
 		gitCommand("rev-parse", "--show-toplevel"),
 		gitCommand("push", "-u", "--force-with-lease", "origin", "issue-fix/71-fix-runner"),

--- a/internal/cli/issue_native.go
+++ b/internal/cli/issue_native.go
@@ -366,6 +366,59 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 		return 1
 	}
 	if !hasChanges {
+		if branchLifecycle == orchestration.BranchLifecycleReused && reusedBranchSync != nil && reusedBranchSync.Changed {
+			if err := a.assertNativeGitContext(ctx, repoRoot, issueBranch, "push sync-only issue branch updates"); err != nil {
+				postState(failedState("commit_push", "restore_branch_context", err.Error()))
+				_, _ = fmt.Fprintf(a.err, "orchestrator: %v\n", err)
+				return 1
+			}
+			if err := a.gitPushBranch(ctx, repoRoot, issueBranch, pushAfterAgentWithLease); err != nil {
+				postState(failedState("commit_push", "inspect_push_failure", err.Error()))
+				_, _ = fmt.Fprintf(a.err, "orchestrator: failed to push sync-only issue branch %q: %v\n", issueBranch, err)
+				return 1
+			}
+			prURL, err := a.issueLifecycle.CreatePullRequest(ctx, lifecycle.CreatePullRequestRequest{
+				Repo:               repo,
+				BaseBranch:         baseBranch,
+				HeadBranch:         issueBranch,
+				Title:              issue.Title,
+				IssueRef:           fmt.Sprintf("#%d", issue.Number),
+				IssueURL:           issue.URL,
+				CloseLinkedIssue:   true,
+				StackedBaseContext: stackedBase,
+			})
+			if err != nil {
+				postState(failedState("pr_ready", "inspect_pr_creation_failure", err.Error()))
+				_, _ = fmt.Fprintf(a.err, "orchestrator: failed to create PR for sync-only issue #%d: %v\n", issue.Number, err)
+				return 1
+			}
+			prNumber := parsePullRequestNumber(prURL)
+			postState(orchestration.TrackedState{
+				Status:           orchestration.StatusReadyForReview,
+				TaskType:         "issue",
+				Issue:            intPtr(issue.Number),
+				PR:               prNumber,
+				Branch:           issueBranch,
+				BranchLifecycle:  branchLifecycle,
+				BaseBranch:       baseBranch,
+				Runner:           runnerName,
+				Agent:            agentName,
+				Model:            modelName,
+				Attempt:          1,
+				Stage:            "pr_ready",
+				NextAction:       "wait_for_review",
+				Error:            "Agent finished without changing files; pushed sync-only branch updates",
+				Timestamp:        time.Now().UTC().Format(time.RFC3339),
+				ReusedBranchSync: reusedBranchSync,
+				Stats:            statsMap(result.Stats),
+			})
+			if prURL != "" {
+				_, _ = fmt.Fprintf(a.out, "No file changes from agent for issue #%d; pushed sync-only branch updates and prepared PR: %s\n", issue.Number, prURL)
+			} else {
+				_, _ = fmt.Fprintf(a.out, "No file changes from agent for issue #%d; pushed sync-only branch updates and prepared PR\n", issue.Number)
+			}
+			return 0
+		}
 		postState(orchestration.TrackedState{
 			Status:           orchestration.StatusWaitingForAuthor,
 			TaskType:         "issue",


### PR DESCRIPTION
## Summary
- Implements fix for #328
- Source issue: https://github.com/podlodka-ai-club/steam-hammer/issues/328

Closes #328
