### PR TITLE
Daemon: classify no-op agent results as retryable instead of waiting-for-author

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1154,8 +1154,8 @@ func TestRunIssueNoopWithExplanationPersistsStructuredReason(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseOrchestrationStateCommentBody(final) error = %v", err)
 	}
-	if finalState.Status != orchestration.StatusBlocked || finalState.NextAction != "inspect_noop_result" {
-		t.Fatalf("final state = %#v, want blocked inspect_noop_result", finalState)
+	if finalState.Status != orchestration.StatusFailed || finalState.NextAction != "inspect_noop_result" {
+		t.Fatalf("final state = %#v, want failed inspect_noop_result", finalState)
 	}
 	if !strings.Contains(finalState.Error, "Feature appears already implemented") {
 		t.Fatalf("final error = %q, want persisted explanation", finalState.Error)
@@ -1214,6 +1214,61 @@ func TestRunIssueNoopWithoutExplanationFailsAsAgentQualityIssue(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), orchestration.NoOpResultMarker) {
 		t.Fatalf("stderr = %q, want missing marker guidance", errOut.String())
+	}
+}
+
+func TestRunIssueNoopWithQuestionPausesForAuthor(t *testing.T) {
+	runner := &recordingRunner{}
+	shell := &fakeShellExecutor{results: []shellExecutionResult{
+		{Stdout: "/repo\n"},
+		{Stdout: ""},
+		{Stdout: "main\n"},
+		{ExitCode: 1},
+		{ExitCode: 2},
+		{},
+		{},
+		{Stdout: ""},
+		{Stdout: "\n"},
+		{Stdout: "issue-fix/71-fix-runner\n"},
+		{Stdout: "/repo\n"},
+	}}
+	lifecycle := &fakeDaemonLifecycle{
+		issue:         githublifecycle.Issue{Number: 71, Title: "Fix runner", Body: "Issue body", URL: "https://github.com/owner/repo/issues/71", Tracker: githublifecycle.TrackerGitHub},
+		defaultBranch: "main",
+	}
+	agent := &fakeIssueAgentRunner{result: &agentexec.Result{Output: strings.Join([]string{
+		"Done",
+		orchestration.NoOpResultMarker,
+		"```json",
+		`{"explanation":"I need one product decision before changing behavior","question":"Should we prefer retryable failure or explicit author pause for this edge case?"}`,
+		"```",
+	}, "\n")}}
+	var out strings.Builder
+	app := NewApp(&out, &strings.Builder{})
+	app.SetRunner(runner)
+	app.SetShellExecutor(shell)
+	app.SetIssueLifecycle(lifecycle)
+	app.SetIssueAgentRunner(agent)
+
+	code := app.Run([]string{"run", "issue", "--id", "71", "--repo", "owner/repo", "--dir", "/repo"})
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if len(lifecycle.commentBodies[71]) != 3 {
+		t.Fatalf("comment bodies = %d, want 3 (state + explanation + final state)", len(lifecycle.commentBodies[71]))
+	}
+	finalState, err := orchestration.ParseOrchestrationStateCommentBody(lifecycle.commentBodies[71][2])
+	if err != nil {
+		t.Fatalf("ParseOrchestrationStateCommentBody(final) error = %v", err)
+	}
+	if finalState.Status != orchestration.StatusWaitingForAuthor || finalState.NextAction != "await_author_reply" {
+		t.Fatalf("final state = %#v, want waiting-for-author await_author_reply", finalState)
+	}
+	if !strings.Contains(finalState.Error, "Question:") {
+		t.Fatalf("final error = %q, want persisted question", finalState.Error)
+	}
+	if !strings.Contains(out.String(), "posted clarification question and paused") {
+		t.Fatalf("stdout = %q, want clarification summary", out.String())
 	}
 }
 

--- a/internal/cli/issue_native.go
+++ b/internal/cli/issue_native.go
@@ -453,7 +453,7 @@ func (a *App) runNativeIssue(ctx context.Context, repo string, opts nativeIssueO
 		if err := a.safePostIssueComment(ctx, repo, issue.Number, orchestration.BuildNoOpResultComment(explanation, nextAction)); err != nil {
 			_, _ = fmt.Fprintf(a.err, "orchestrator: warning: failed to post no-op explanation for issue #%d: %v\n", issue.Number, err)
 		}
-		status := orchestration.StatusBlocked
+		status := orchestration.StatusFailed
 		followUpAction := "inspect_noop_result"
 		if question != "" {
 			status = orchestration.StatusWaitingForAuthor

--- a/internal/core/orchestration/daemon_policy_test.go
+++ b/internal/core/orchestration/daemon_policy_test.go
@@ -266,6 +266,32 @@ func TestEvaluateDaemonTaskSelectionSkipsFailureUntilBackoffElapsed(t *testing.T
 	}
 }
 
+func TestEvaluateDaemonTaskSelectionNoopFailureRespectsBackoffThenBecomesRunnable(t *testing.T) {
+	policy := DaemonRetryPolicy{MaxAttempts: 3, Backoff: 5 * time.Minute}
+	snapshot := DaemonTaskSnapshot{
+		IssueNumber:          249,
+		LatestStateStatus:    StatusFailed,
+		LatestStateAttempt:   1,
+		LatestStateTimestamp: time.Date(2026, 5, 1, 11, 59, 0, 0, time.UTC),
+	}
+
+	waiting := EvaluateDaemonTaskSelection(snapshot, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), policy)
+	if waiting.Eligible {
+		t.Fatalf("Eligible = true, want false")
+	}
+	if waiting.Status != DaemonSelectionStatusWaiting || waiting.Code != DaemonSelectionCodeRetryBackoff {
+		t.Fatalf("waiting decision status/code = %q/%q", waiting.Status, waiting.Code)
+	}
+
+	runnable := EvaluateDaemonTaskSelection(snapshot, time.Date(2026, 5, 1, 12, 6, 0, 0, time.UTC), policy)
+	if !runnable.Eligible {
+		t.Fatalf("Eligible = false, want true (%q)", runnable.Reason)
+	}
+	if runnable.Status != DaemonSelectionStatusRunnable || runnable.Code != DaemonSelectionCodeRunnable {
+		t.Fatalf("runnable decision status/code = %q/%q", runnable.Status, runnable.Code)
+	}
+}
+
 func TestEvaluateDaemonTaskSelectionSkipsRetryLimitReached(t *testing.T) {
 	decision := EvaluateDaemonTaskSelection(DaemonTaskSnapshot{
 		IssueNumber:        249,


### PR DESCRIPTION
## Summary
- Implements fix for #367
- Source issue: https://github.com/podlodka-ai-club/steam-hammer/issues/367

Closes #367
